### PR TITLE
Allow sub-command mode.

### DIFF
--- a/lib/Term/CLI.pm
+++ b/lib/Term/CLI.pm
@@ -60,7 +60,6 @@ extends 'Term::CLI::Base';
 with('Term::CLI::Role::CommandSet');
 
 my $DFL_HIST_SIZE = 1000;
-my $ERROR_STATUS  = -1;
 
 # Provide a default for 'name'.
 has '+name' => ( default => sub {$FindBin::Script} );
@@ -231,8 +230,7 @@ sub _rl_completion_quote_character {
 
 # See POD X<complete_line>
 sub complete_line {
-    my $self = shift;
-    $self->_complete_line( @_ );
+    shift()->_complete_line( @_ );
 }
 
 sub read_history {
@@ -260,37 +258,7 @@ sub write_history {
 }
 
 sub execute {
-    my ( $self, $cmd ) = @_;
-
-    my ( $error, @cmd ) = $self->_split_line($cmd);
-
-    my %args = (
-        status       => 0,
-        error        => q{},
-        command_line => $cmd,
-        command_path => [$self],
-        unparsed     => \@cmd,
-        options      => {},
-        arguments    => [],
-    );
-
-    return $self->try_callback( %args, status => $ERROR_STATUS,
-        error => $error )
-        if length $error;
-
-    if ( @cmd == 0 ) {
-        $args{error}  = loc("missing command");
-        $args{status} = $ERROR_STATUS;
-    }
-    elsif ( my $cmd_ref = $self->find_command( $cmd[0] ) ) {
-        %args = $cmd_ref->execute( %args, unparsed => [ @cmd[ 1 .. $#cmd ] ] );
-    }
-    else {
-        $args{error}  = $self->error;
-        $args{status} = $ERROR_STATUS;
-    }
-
-    return $self->try_callback(%args);
+    shift()->_execute( @_ );
 }
 
 1;

--- a/lib/Term/CLI/Command.pm
+++ b/lib/Term/CLI/Command.pm
@@ -172,7 +172,8 @@ sub execute {
             %args = $self->_check_arguments(%args);
         }
     }
-    if ( $args{status} >= 0 and $self->has_commands ) {
+    if ( $args{status} >= 0 and $self->has_commands
+         && ! ( @{ $args{unparsed} } == 0 && $self->missing_cmd_ok )  ) {
         %args = $self->_execute_command(%args);
     }
     return $self->try_callback(%args);

--- a/lib/Term/CLI/Command/Help.pm
+++ b/lib/Term/CLI/Command/Help.pm
@@ -167,7 +167,7 @@ sub _get_help {
         my ( $pod, $text ) = $self->_make_command_summary(
             cmd_path   => [],
             pod_prefix => "=head2 " . loc("Commands") . ":\n\n",
-            commands   => [ $self->root_node->commands ]
+            commands   => [ $self->parent->commands ]
         );
         return ( %args, pod => $pod, text => $text );
     }
@@ -175,7 +175,7 @@ sub _get_help {
     # We've been given arguments to "help". Find the
     # appropriate command object, and work from there.
 
-    my $cur_cmd_ref = $self->root_node;
+    my $cur_cmd_ref = $self->parent;
     my @cmd_ref_path;
 
     for my $cmd_name ( @{ $args{arguments} } ) {
@@ -268,7 +268,7 @@ sub _get_help_all_commands {
     my ( $self, %args ) = @_;
 
     my @cmd_path = @{ $args{cmd_path} // [] };
-    my $cmd      = $cmd_path[-1] // $self->root_node;
+    my $cmd      = $cmd_path[-1] // $self->parent;
 
     my $pod = '';
 
@@ -289,7 +289,7 @@ sub _get_all_help {
     my ( $pod1, $txt1 ) = $self->_make_command_summary(
         cmd_path   => [],
         pod_prefix => "=head1 " . loc("COMMAND SUMMARY") . "\n\n",
-        commands   => [ $self->root_node->commands ]
+        commands   => [ $self->parent->commands ]
     );
 
     my $pod2 =
@@ -337,7 +337,7 @@ sub complete_line {
         }
     }
 
-    my $cur_cmd_ref = $self->root_node;
+    my $cur_cmd_ref = $self->parent;
     while (@words) {
         my $new_cmd_ref = $cur_cmd_ref->find_command( $words[0] );
         if ( !$new_cmd_ref ) {


### PR DESCRIPTION
This provides partial support for "Sub-command" Mode, where a subcommand takes control and appears to be the top-level command.

This allows things like this:

```
test> help
  Commands:
    help [cmd ...]                show help
    loop {copy|exit|help|move}    Sub-command mode test
test> loop
loop> help
  Commands:
    copy              copy something
    exit              exit something
    help [cmd ...]    show help
    move              move something
loop> copy
copy...
loop> exit
exit...
test>
```
On to the commit.  

## Term::CLI::Command::Help

This is the cleanest change, namely using `$self->parent` instead of `$self->root_node`.  For the top level help, this doesn't change behavior, as they are the same; lower level help now only pays attention to its immediate parent, which is what is desired in this case.

## Term::CLI & Term::CLI::Command

This part is messy.  Getting an ordinary `Term::CLI::Command` to accept input and get proper command completion involved moving some functionality out of `Term::CLI` into `Term::CLI::CommandSet`, namely `complete_line`, `readline`, and `_set_completion_attributes`.  This allows `$self` to refer to the `Term::CLI::Command` and make customization of `readline` et. al possible.

(Arguably, more could have been moved into `Term::CLI::CommandSet`, such as `quote_characters` and `word_delimiters`.  The code in `Term::CLI::CommandSet` directly calls those methods on the root node. `Term:CLI::CommandSet::root_node` was tweaked so that `Term::CLI` objects are their own root node.

`Term::CLI::complete_line` and `Term::CLI::CommandSet::complete_line` are totally different beasts, so simply moving the former into `Term::CLI::CommandSet` doesn't work. Its now called `Term::CLI::CommandSet::_complete_line`, with a wrapper in `Term::CLI` to keep the API.

`_set_completion_attributes` (which is called by a `readline`, amongst others), now ensures that `readline` sees the proper completion function.

## Loose Ends

There are some hacks still required in the subcommand to work around the following:

1. Term::CLI will error if it sees a command without a subcommand, e.g.
`test> loop`
will cause a "missing subcommand" error. In the example code below, I use a hack to work around this. This could be mediated with an attribute in  `Command` which can be queried to determine if a missing subcommand is indeed an error.

2. The subcommand still uses the top level $cli->execute, so must add itself
   back into the command after getting the input, e.g.
`$cli->execute( $self->name . ' ' . $input );`
in order to get command dispatching to work correctly.  One way to work around this would be to move `Term::CLI::execute` into `Term::CLI::Role::CommandSet::_execute` (to avoid a clash with `Term::CLI::Command::execute`).

# Example use

```
#! /usr/bin/env perl

use strict;
use warnings;

use v5.14;

use Term::CLI;
use Term::CLI::L10N 'loc';
use Scalar::Util qw( refaddr );

my $cli = Term::CLI->new(
    name     => 'test',
    prompt   => 'test> ',
    commands => [ Term::CLI::Command::Help->new, Loop() ],
);

while ( my $input = $cli->readline() ) {
    my %args = eval { $cli->execute( $input ); };
    say $@ if $@ ne '';
}

sub Loop {

    Term::CLI::Command->new(
        name     => 'loop',
        commands => [
            Term::CLI::Command::Help->new(),
            subcommand( 'copy', 'move', 'exit' ),
        ],
        summary  => 'Sub-command mode test',
        callback => sub {
            my ( $self, %args ) = @_;

            # no-op if there actually was a subcommand.
            # Compare $self to the last command in $args{command_path}.
            # HOWEVER: the  docs in Term::CLI::Role::CommandSet say that
            # $args{command_path}[-1] === $self, but that's seem to be
            # only the case when $self is the leaf node.
            return %args
              if refaddr( $self ) != refaddr( $args{command_path}[-1] );

            # THIS IS HORRIBLE. :(
            # ignore error if Term::CLI saw we have subcommands and
            # none were provided
            return %args
              if $args{status} != 0
              && $args{error} ne loc( "missing sub-command" );

            # need to reset these because of the "missing sub-command" error.
            $args{status} = 0;
            $args{error}  = '';

            my $cli = $self->root_node;

            while ( my $input
                = $self->readline( prompt => $self->name . '> ' ) )
            {
                my %args = eval {
                    # THIS IS HORRIBLE. :(
                    # use the root's execute command, but prefix it
                    # with ourselves so it gets dispatched correctly.
                    $cli->execute( $self->name . ' ' . $input );
                };
                say $@ if $@ ne '';

                last if $args{command_path}[-1]{name} eq 'exit';
            }

            return %args;
        },
    );
}

# create some no-op subcommands
sub subcommand {

    map {
         $name = $_;
        Term::CLI::Command->new(
            name     => $name,
            summary  => "\F$name something",
            callback => sub {
                my ( $self, %args ) = @_;
                say "\F$name...";
                return %args;
            } )
    } @_;
}
```
