### PR TITLE
Feature/completion context

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -12,6 +12,14 @@ Makefile.PL
 README.md
 cpanfile
 examples/cli_context.pl
+examples/context_sensitive_completion/README.md
+examples/context_sensitive_completion/cli_demo.pl
+examples/context_sensitive_completion/data/README.md
+examples/context_sensitive_completion/data/continents.json
+examples/context_sensitive_completion/data/countries.json
+examples/context_sensitive_completion/data/data.json
+examples/context_sensitive_completion/data/munge_country_data.pl
+examples/getopt_test.pl
 examples/readline_cli.pl
 examples/readline_completion_demo.pl
 examples/simple_cli.pl
@@ -39,6 +47,7 @@ lib/Term/CLI/Role/ArgumentSet.pm
 lib/Term/CLI/Role/CommandSet.pm
 lib/Term/CLI/Role/HelpText.pm
 lib/Term/CLI/Tutorial.pod
+lib/Term/CLI/Util.pm
 pkg/fedora/perl-Term-CLI.spec
 t/000-compile.t
 t/015-Term-CLI-Element.t
@@ -47,6 +56,7 @@ t/023-Term-CLI-Argument-String.t
 t/025-Term-CLI-Argument-Enum.t
 t/026-Term-CLI-Argument-Enum-Dynamic.t
 t/027-Term-CLI-Argument-Bool.t
+t/028-Term-CLI-Argument-Enum-Cache.t
 t/030-Term-CLI-Argument-Filename.t
 t/035-Term-CLI-Argument-Number.t
 t/040-Term-CLI-Argument-Number-Int.t
@@ -78,3 +88,4 @@ tutorial/example_14_sub_cmd_and_args.pl
 tutorial/example_15_debug_command.pl
 tutorial/example_16_options.pl
 tutorial/example_17_suspend.pl
+tutorial/example_18_dynamic_enum.pl

--- a/examples/context_sensitive_completion/README.md
+++ b/examples/context_sensitive_completion/README.md
@@ -1,0 +1,1 @@
+Demo to showcase context-sensitive completion.

--- a/examples/context_sensitive_completion/cli_demo.pl
+++ b/examples/context_sensitive_completion/cli_demo.pl
@@ -14,23 +14,23 @@ use Term::CLI;
 sub Main {
     my $term = setup_term();
 
-    while (defined(my $cmd_line = $term->readline)) {
+    while ( defined( my $cmd_line = $term->readline ) ) {
         $term->execute($cmd_line);
     }
     print "\n";
-    execute_exit('exit', 0);
+    execute_exit( 'exit', 0 );
 }
 
 sub load_json {
     my ($fname) = @_;
     my $text = read_file($fname);
 
-    state $js_obj = JSON::MaybeXS->new(utf8 => 1);
+    state $js_obj = JSON::MaybeXS->new( utf8 => 1 );
     return $js_obj->decode($text);
 }
 
 sub execute_exit {
-    my ($cmd, @args) = @_;
+    my ( $cmd, @args ) = @_;
     my $excode = $args[0] // 0;
     say "-- exit: $excode";
     exit $excode;
@@ -42,62 +42,64 @@ sub setup_term {
     my $country_data = load_json('./data/data.json');
 
     my $term = Term::CLI->new(
-        name => 'csc',
-        prompt => 'csc> ',
-        skip => qr/^\s*(?:#.*)?$/,
+        name          => 'csc',
+        prompt        => 'csc> ',
+        skip          => qr/^\s*(?:#.*)?$/,
         history_lines => 100,
     );
 
     push @commands, Term::CLI::Command->new(
-        name => 'show',
-        usage => 'B<show> I<continent> [I<country> [I<city>]]',
-        summary => 'show information about a location',
+        name        => 'show',
+        usage       => 'B<show> I<continent> [I<country> [I<city>]]',
+        summary     => 'show information about a location',
         description => 'Show information about a region, country, or city.',
-        arguments => [
+        arguments   => [
             Term::CLI::Argument::Continent->new(
-                name => 'continent',
+                name         => 'continent',
                 country_data => $country_data,
             ),
             Term::CLI::Argument::Country->new(
-                name => 'country',
+                name         => 'country',
                 country_data => $country_data,
-                min_occur => 0,
+                min_occur    => 0,
             ),
             Term::CLI::Argument::City->new(
-                name => 'city',
+                name         => 'city',
                 country_data => $country_data,
-                min_occur => 0,
+                min_occur    => 0,
             ),
         ],
         callback => sub {
-            my ($cmd, %args) = @_;
+            my ( $cmd, %args ) = @_;
             return %args if $args{status} < 0;
-            my ($continent, $country, $city) = @{$args{arguments}};
+            my ( $continent, $country, $city ) = @{ $args{arguments} };
             if ($city) {
-                show_city($city, $country_data);
+                show_city( $city, $country_data );
                 return %args;
             }
             if ($country) {
-                show_country($country, $country_data);
+                show_country( $country, $country_data );
                 return %args;
             }
-            show_continent($continent, $country_data);
+            show_continent( $continent, $country_data );
             return %args;
         }
     );
 
     push @commands, Term::CLI::Command->new(
-        name => 'exit',
+        name      => 'exit',
         arguments => [
-            Term::CLI::Argument::Number::Int->new( name => 'code',
+            Term::CLI::Argument::Number::Int->new(
+                name      => 'code',
                 min_occur => 0,
-                min => 0, inclusive => 1
+                min       => 0,
+                inclusive => 1
             ),
         ],
         callback => sub {
-            my ($cmd, %args) = @_;
+            my ( $cmd, %args ) = @_;
             return %args if $args{status} < 0;
-            execute_exit($cmd->name, @{$args{arguments}});
+            execute_exit( $cmd->name, @{ $args{arguments} } );
             return %args;
         }
     );
@@ -109,24 +111,24 @@ sub setup_term {
 }
 
 sub show_city {
-    my ($city, $country_data) = @_;
+    my ( $city, $country_data ) = @_;
     my $city_record = $country_data->{cities}->{$city};
-    print JSON::MaybeXS->new(pretty => 1, canonical => 1)
+    print JSON::MaybeXS->new( pretty => 1, canonical => 1 )
         ->encode($city_record);
 }
 
 sub show_country {
-    my ($country, $country_data) = @_;
+    my ( $country, $country_data ) = @_;
     my $country_record = $country_data->{countries}->{$country};
-    print JSON::MaybeXS->new(pretty => 1, canonical => 1)
-            ->encode($country_record);
+    print JSON::MaybeXS->new( pretty => 1, canonical => 1 )
+        ->encode($country_record);
 }
 
 sub show_continent {
-    my ($continent, $country_data) = @_;
+    my ( $continent, $country_data ) = @_;
     my $continent_record = $country_data->{continents}->{$continent};
-    print JSON::MaybeXS->new(pretty => 1, canonical => 1)
-            ->encode($continent_record);
+    print JSON::MaybeXS->new( pretty => 1, canonical => 1 )
+        ->encode($continent_record);
 }
 
 package Term::CLI::Argument::Continent {
@@ -136,65 +138,100 @@ package Term::CLI::Argument::Continent {
     around BUILDARGS => sub {
         my ( $orig, $class, @args ) = @_;
         return $class->$orig(@args) if @args % 2;
-        my %args = @args;
+        my %args         = @args;
         my $country_data = $args{country_data} // {};
-        return $class->$orig(
-            @args,
-            value_list => [ sort keys %{$country_data->{continents}} ],
-        );
+        return $class->$orig( @args,
+            value_list => [ sort keys %{ $country_data->{continents} } ], );
     };
 }
 
 package Term::CLI::Argument::Country {
     use Moo;
+
+    use namespace::clean;
+
     extends 'Term::CLI::Argument::Enum';
+
     has country_data => ( is => 'ro', required => 1 );
 
     around BUILDARGS => sub {
         my ( $orig, $class, @args ) = @_;
         return $class->$orig(@args) if @args % 2;
-        my %args = @args;
+        my %args         = @args;
         my $country_data = $args{country_data} // {};
-        return $class->$orig(
-            @args,
-            value_list => [ sort keys %{$country_data->{countries}} ],
-        );
+        return $class->$orig( @args,
+            value_list => [ sort keys %{ $country_data->{countries} } ], );
     };
 
     sub complete {
-        my ($self, $text, $state) = @_;
+        my ( $self, $text, $state ) = @_;
         my $continent = $state->{processed}->[-1];
         my $values = $self->country_data->{continents}{$continent}{countries};
-        return (sort @{$values}) if !length $text;
-        return (
-            sort grep { substr( $_, 0, length $text ) eq $text } @{$values}
-        );
+        return ( sort @{$values} ) if !length $text;
+        return ( sort grep { substr( $_, 0, length $text ) eq $text }
+                @{$values} );
+    }
+
+    sub validate {
+        my ( $self, $text, $state ) = @_;
+
+        my $country_record = $self->country_data->{countries}->{$text};
+
+        return $self->set_error("not a valid country name")
+            if !$country_record;
+
+        my $continent = $state->{arguments}->[-1];
+
+        return $self->set_error("not a valid country name in $continent")
+            if $country_record->{continent} ne $continent;
+
+        return $text;
     }
 }
 
 package Term::CLI::Argument::City {
     use Moo;
+    use List::Util qw( first );
+
+    use namespace::clean;
+
     extends 'Term::CLI::Argument::Enum';
+
     has country_data => ( is => 'ro', required => 1 );
+
     around BUILDARGS => sub {
         my ( $orig, $class, @args ) = @_;
         return $class->$orig(@args) if @args % 2;
-        my %args = @args;
+        my %args         = @args;
         my $country_data = $args{country_data} // {};
-        return $class->$orig(
-            @args,
-            value_list => [ sort keys %{$country_data->{cities}} ],
-        );
+        return $class->$orig( @args,
+            value_list => [ sort keys %{ $country_data->{cities} } ], );
     };
 
     sub complete {
-        my ($self, $text, $state) = @_;
+        my ( $self, $text, $state ) = @_;
         my $country = $state->{processed}->[-1];
-        my $values = $self->country_data->{countries}{$country}{cities};
-        return (sort @{$values}) if !length $text;
-        return (
-            sort grep { substr( $_, 0, length $text ) eq $text } @{$values}
-        );
+        my $values  = $self->country_data->{countries}{$country}{cities};
+        return ( sort @{$values} ) if !length $text;
+        return ( sort grep { substr( $_, 0, length $text ) eq $text }
+                @{$values} );
+    }
+
+    sub validate {
+        my ( $self, $text, $state ) = @_;
+
+        my $city_record = $self->country_data->{cities}->{$text};
+
+        return $self->set_error("not a valid city name")
+            if !$city_record;
+
+        my $country = $state->{arguments}->[-1];
+
+        if ( !first { $_ eq $country } @{ $city_record->{countries} } ) {
+            return $self->set_error("not a valid city name in $country");
+        }
+
+        return $text;
     }
 }
 

--- a/examples/context_sensitive_completion/cli_demo.pl
+++ b/examples/context_sensitive_completion/cli_demo.pl
@@ -1,0 +1,201 @@
+#!/usr/bin/env perl
+
+use 5.014_001;
+use warnings;
+use FindBin;
+use lib ("$FindBin::Bin/../../lib");
+
+use open qw( :std :utf8 );
+use File::Slurp;
+use JSON::MaybeXS;
+
+use Term::CLI;
+
+sub Main {
+    my $term = setup_term();
+
+    while (defined(my $cmd_line = $term->readline)) {
+        $term->execute($cmd_line);
+    }
+    print "\n";
+    execute_exit('exit', 0);
+}
+
+sub load_json {
+    my ($fname) = @_;
+    my $text = read_file($fname);
+
+    state $js_obj = JSON::MaybeXS->new(utf8 => 1);
+    return $js_obj->decode($text);
+}
+
+sub execute_exit {
+    my ($cmd, @args) = @_;
+    my $excode = $args[0] // 0;
+    say "-- exit: $excode";
+    exit $excode;
+}
+
+sub setup_term {
+    my @commands;
+
+    my $country_data = load_json('./data/data.json');
+
+    my $term = Term::CLI->new(
+        name => 'csc',
+        prompt => 'csc> ',
+        skip => qr/^\s*(?:#.*)?$/,
+        history_lines => 100,
+    );
+
+    push @commands, Term::CLI::Command->new(
+        name => 'show',
+        usage => 'B<show> I<continent> [I<country> [I<city>]]',
+        summary => 'show information about a location',
+        description => 'Show information about a region, country, or city.',
+        arguments => [
+            Term::CLI::Argument::Continent->new(
+                name => 'continent',
+                country_data => $country_data,
+            ),
+            Term::CLI::Argument::Country->new(
+                name => 'country',
+                country_data => $country_data,
+                min_occur => 0,
+            ),
+            Term::CLI::Argument::City->new(
+                name => 'city',
+                country_data => $country_data,
+                min_occur => 0,
+            ),
+        ],
+        callback => sub {
+            my ($cmd, %args) = @_;
+            return %args if $args{status} < 0;
+            my ($continent, $country, $city) = @{$args{arguments}};
+            if ($city) {
+                show_city($city, $country_data);
+                return %args;
+            }
+            if ($country) {
+                show_country($country, $country_data);
+                return %args;
+            }
+            show_continent($continent, $country_data);
+            return %args;
+        }
+    );
+
+    push @commands, Term::CLI::Command->new(
+        name => 'exit',
+        arguments => [
+            Term::CLI::Argument::Number::Int->new( name => 'code',
+                min_occur => 0,
+                min => 0, inclusive => 1
+            ),
+        ],
+        callback => sub {
+            my ($cmd, %args) = @_;
+            return %args if $args{status} < 0;
+            execute_exit($cmd->name, @{$args{arguments}});
+            return %args;
+        }
+    );
+
+    push @commands, Term::CLI::Command::Help->new();
+
+    $term->add_command(@commands);
+    return $term;
+}
+
+sub show_city {
+    my ($city, $country_data) = @_;
+    my $city_record = $country_data->{cities}->{$city};
+    print JSON::MaybeXS->new(pretty => 1, canonical => 1)
+        ->encode($city_record);
+}
+
+sub show_country {
+    my ($country, $country_data) = @_;
+    my $country_record = $country_data->{countries}->{$country};
+    print JSON::MaybeXS->new(pretty => 1, canonical => 1)
+            ->encode($country_record);
+}
+
+sub show_continent {
+    my ($continent, $country_data) = @_;
+    my $continent_record = $country_data->{continents}->{$continent};
+    print JSON::MaybeXS->new(pretty => 1, canonical => 1)
+            ->encode($continent_record);
+}
+
+package Term::CLI::Argument::Continent {
+    use Moo;
+    extends 'Term::CLI::Argument::Enum';
+    has country_data => ( is => 'ro', required => 1 );
+    around BUILDARGS => sub {
+        my ( $orig, $class, @args ) = @_;
+        return $class->$orig(@args) if @args % 2;
+        my %args = @args;
+        my $country_data = $args{country_data} // {};
+        return $class->$orig(
+            @args,
+            value_list => [ sort keys %{$country_data->{continents}} ],
+        );
+    };
+}
+
+package Term::CLI::Argument::Country {
+    use Moo;
+    extends 'Term::CLI::Argument::Enum';
+    has country_data => ( is => 'ro', required => 1 );
+
+    around BUILDARGS => sub {
+        my ( $orig, $class, @args ) = @_;
+        return $class->$orig(@args) if @args % 2;
+        my %args = @args;
+        my $country_data = $args{country_data} // {};
+        return $class->$orig(
+            @args,
+            value_list => [ sort keys %{$country_data->{countries}} ],
+        );
+    };
+
+    sub complete {
+        my ($self, $text, $state) = @_;
+        my $continent = $state->{processed}->[-1];
+        my $values = $self->country_data->{continents}{$continent}{countries};
+        return (sort @{$values}) if !length $text;
+        return (
+            sort grep { substr( $_, 0, length $text ) eq $text } @{$values}
+        );
+    }
+}
+
+package Term::CLI::Argument::City {
+    use Moo;
+    extends 'Term::CLI::Argument::Enum';
+    has country_data => ( is => 'ro', required => 1 );
+    around BUILDARGS => sub {
+        my ( $orig, $class, @args ) = @_;
+        return $class->$orig(@args) if @args % 2;
+        my %args = @args;
+        my $country_data = $args{country_data} // {};
+        return $class->$orig(
+            @args,
+            value_list => [ sort keys %{$country_data->{cities}} ],
+        );
+    };
+
+    sub complete {
+        my ($self, $text, $state) = @_;
+        my $country = $state->{processed}->[-1];
+        my $values = $self->country_data->{countries}{$country}{cities};
+        return (sort @{$values}) if !length $text;
+        return (
+            sort grep { substr( $_, 0, length $text ) eq $text } @{$values}
+        );
+    }
+}
+
+Main;

--- a/examples/context_sensitive_completion/data/README.md
+++ b/examples/context_sensitive_completion/data/README.md
@@ -1,0 +1,7 @@
+Data sources for `countries.json` and `continents.json`:
+
+ * https://github.com/annexare/Countries
+ * https://raw.githubusercontent.com/annexare/Countries/master/data/continents.json
+ * https://raw.githubusercontent.com/annexare/Countries/master/data/countries.json
+
+The `munge_country_data.pl` script processes the source JSON to a combined JSON data structure `data.json` for the `cli_demo.pl` script in the parent directory.

--- a/examples/context_sensitive_completion/data/continents.json
+++ b/examples/context_sensitive_completion/data/continents.json
@@ -1,0 +1,9 @@
+{
+  "AF": "Africa",
+  "AN": "Antarctica",
+  "AS": "Asia",
+  "EU": "Europe",
+  "NA": "North America",
+  "OC": "Oceania",
+  "SA": "South America"
+}

--- a/examples/context_sensitive_completion/data/countries.json
+++ b/examples/context_sensitive_completion/data/countries.json
@@ -1,0 +1,3921 @@
+{
+  "AD": {
+    "name": "Andorra",
+    "native": "Andorra",
+    "phone": [
+      376
+    ],
+    "continent": "EU",
+    "capital": "Andorra la Vella",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "ca"
+    ]
+  },
+  "AE": {
+    "name": "United Arab Emirates",
+    "native": "دولة الإمارات العربية المتحدة",
+    "phone": [
+      971
+    ],
+    "continent": "AS",
+    "capital": "Abu Dhabi",
+    "currency": [
+      "AED"
+    ],
+    "languages": [
+      "ar"
+    ]
+  },
+  "AF": {
+    "name": "Afghanistan",
+    "native": "افغانستان",
+    "phone": [
+      93
+    ],
+    "continent": "AS",
+    "capital": "Kabul",
+    "currency": [
+      "AFN"
+    ],
+    "languages": [
+      "ps",
+      "uz",
+      "tk"
+    ]
+  },
+  "AG": {
+    "name": "Antigua and Barbuda",
+    "native": "Antigua and Barbuda",
+    "phone": [
+      1268
+    ],
+    "continent": "NA",
+    "capital": "Saint John's",
+    "currency": [
+      "XCD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "AI": {
+    "name": "Anguilla",
+    "native": "Anguilla",
+    "phone": [
+      1264
+    ],
+    "continent": "NA",
+    "capital": "The Valley",
+    "currency": [
+      "XCD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "AL": {
+    "name": "Albania",
+    "native": "Shqipëria",
+    "phone": [
+      355
+    ],
+    "continent": "EU",
+    "capital": "Tirana",
+    "currency": [
+      "ALL"
+    ],
+    "languages": [
+      "sq"
+    ]
+  },
+  "AM": {
+    "name": "Armenia",
+    "native": "Հայաստան",
+    "phone": [
+      374
+    ],
+    "continent": "AS",
+    "capital": "Yerevan",
+    "currency": [
+      "AMD"
+    ],
+    "languages": [
+      "hy",
+      "ru"
+    ]
+  },
+  "AO": {
+    "name": "Angola",
+    "native": "Angola",
+    "phone": [
+      244
+    ],
+    "continent": "AF",
+    "capital": "Luanda",
+    "currency": [
+      "AOA"
+    ],
+    "languages": [
+      "pt"
+    ]
+  },
+  "AQ": {
+    "name": "Antarctica",
+    "native": "Antarctica",
+    "phone": [
+      672
+    ],
+    "continent": "AN",
+    "capital": "",
+    "currency": [],
+    "languages": []
+  },
+  "AR": {
+    "name": "Argentina",
+    "native": "Argentina",
+    "phone": [
+      54
+    ],
+    "continent": "SA",
+    "capital": "Buenos Aires",
+    "currency": [
+      "ARS"
+    ],
+    "languages": [
+      "es",
+      "gn"
+    ]
+  },
+  "AS": {
+    "name": "American Samoa",
+    "native": "American Samoa",
+    "phone": [
+      1684
+    ],
+    "continent": "OC",
+    "capital": "Pago Pago",
+    "currency": [
+      "USD"
+    ],
+    "languages": [
+      "en",
+      "sm"
+    ]
+  },
+  "AT": {
+    "name": "Austria",
+    "native": "Österreich",
+    "phone": [
+      43
+    ],
+    "continent": "EU",
+    "capital": "Vienna",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "de"
+    ]
+  },
+  "AU": {
+    "name": "Australia",
+    "native": "Australia",
+    "phone": [
+      61
+    ],
+    "continent": "OC",
+    "capital": "Canberra",
+    "currency": [
+      "AUD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "AW": {
+    "name": "Aruba",
+    "native": "Aruba",
+    "phone": [
+      297
+    ],
+    "continent": "NA",
+    "capital": "Oranjestad",
+    "currency": [
+      "AWG"
+    ],
+    "languages": [
+      "nl",
+      "pa"
+    ]
+  },
+  "AX": {
+    "name": "Åland",
+    "native": "Åland",
+    "phone": [
+      358
+    ],
+    "continent": "EU",
+    "capital": "Mariehamn",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "sv"
+    ]
+  },
+  "AZ": {
+    "name": "Azerbaijan",
+    "native": "Azərbaycan",
+    "phone": [
+      994
+    ],
+    "continent": "AS",
+    "continents": [
+      "AS",
+      "EU"
+    ],
+    "capital": "Baku",
+    "currency": [
+      "AZN"
+    ],
+    "languages": [
+      "az"
+    ]
+  },
+  "BA": {
+    "name": "Bosnia and Herzegovina",
+    "native": "Bosna i Hercegovina",
+    "phone": [
+      387
+    ],
+    "continent": "EU",
+    "capital": "Sarajevo",
+    "currency": [
+      "BAM"
+    ],
+    "languages": [
+      "bs",
+      "hr",
+      "sr"
+    ]
+  },
+  "BB": {
+    "name": "Barbados",
+    "native": "Barbados",
+    "phone": [
+      1246
+    ],
+    "continent": "NA",
+    "capital": "Bridgetown",
+    "currency": [
+      "BBD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "BD": {
+    "name": "Bangladesh",
+    "native": "Bangladesh",
+    "phone": [
+      880
+    ],
+    "continent": "AS",
+    "capital": "Dhaka",
+    "currency": [
+      "BDT"
+    ],
+    "languages": [
+      "bn"
+    ]
+  },
+  "BE": {
+    "name": "Belgium",
+    "native": "België",
+    "phone": [
+      32
+    ],
+    "continent": "EU",
+    "capital": "Brussels",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "nl",
+      "fr",
+      "de"
+    ]
+  },
+  "BF": {
+    "name": "Burkina Faso",
+    "native": "Burkina Faso",
+    "phone": [
+      226
+    ],
+    "continent": "AF",
+    "capital": "Ouagadougou",
+    "currency": [
+      "XOF"
+    ],
+    "languages": [
+      "fr",
+      "ff"
+    ]
+  },
+  "BG": {
+    "name": "Bulgaria",
+    "native": "България",
+    "phone": [
+      359
+    ],
+    "continent": "EU",
+    "capital": "Sofia",
+    "currency": [
+      "BGN"
+    ],
+    "languages": [
+      "bg"
+    ]
+  },
+  "BH": {
+    "name": "Bahrain",
+    "native": "‏البحرين",
+    "phone": [
+      973
+    ],
+    "continent": "AS",
+    "capital": "Manama",
+    "currency": [
+      "BHD"
+    ],
+    "languages": [
+      "ar"
+    ]
+  },
+  "BI": {
+    "name": "Burundi",
+    "native": "Burundi",
+    "phone": [
+      257
+    ],
+    "continent": "AF",
+    "capital": "Bujumbura",
+    "currency": [
+      "BIF"
+    ],
+    "languages": [
+      "fr",
+      "rn"
+    ]
+  },
+  "BJ": {
+    "name": "Benin",
+    "native": "Bénin",
+    "phone": [
+      229
+    ],
+    "continent": "AF",
+    "capital": "Porto-Novo",
+    "currency": [
+      "XOF"
+    ],
+    "languages": [
+      "fr"
+    ]
+  },
+  "BL": {
+    "name": "Saint Barthélemy",
+    "native": "Saint-Barthélemy",
+    "phone": [
+      590
+    ],
+    "continent": "NA",
+    "capital": "Gustavia",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "fr"
+    ]
+  },
+  "BM": {
+    "name": "Bermuda",
+    "native": "Bermuda",
+    "phone": [
+      1441
+    ],
+    "continent": "NA",
+    "capital": "Hamilton",
+    "currency": [
+      "BMD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "BN": {
+    "name": "Brunei",
+    "native": "Negara Brunei Darussalam",
+    "phone": [
+      673
+    ],
+    "continent": "AS",
+    "capital": "Bandar Seri Begawan",
+    "currency": [
+      "BND"
+    ],
+    "languages": [
+      "ms"
+    ]
+  },
+  "BO": {
+    "name": "Bolivia",
+    "native": "Bolivia",
+    "phone": [
+      591
+    ],
+    "continent": "SA",
+    "capital": "Sucre",
+    "currency": [
+      "BOB",
+      "BOV"
+    ],
+    "languages": [
+      "es",
+      "ay",
+      "qu"
+    ]
+  },
+  "BQ": {
+    "name": "Bonaire",
+    "native": "Bonaire",
+    "phone": [
+      5997
+    ],
+    "continent": "NA",
+    "capital": "Kralendijk",
+    "currency": [
+      "USD"
+    ],
+    "languages": [
+      "nl"
+    ]
+  },
+  "BR": {
+    "name": "Brazil",
+    "native": "Brasil",
+    "phone": [
+      55
+    ],
+    "continent": "SA",
+    "capital": "Brasília",
+    "currency": [
+      "BRL"
+    ],
+    "languages": [
+      "pt"
+    ]
+  },
+  "BS": {
+    "name": "Bahamas",
+    "native": "Bahamas",
+    "phone": [
+      1242
+    ],
+    "continent": "NA",
+    "capital": "Nassau",
+    "currency": [
+      "BSD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "BT": {
+    "name": "Bhutan",
+    "native": "ʼbrug-yul",
+    "phone": [
+      975
+    ],
+    "continent": "AS",
+    "capital": "Thimphu",
+    "currency": [
+      "BTN",
+      "INR"
+    ],
+    "languages": [
+      "dz"
+    ]
+  },
+  "BV": {
+    "name": "Bouvet Island",
+    "native": "Bouvetøya",
+    "phone": [
+      47
+    ],
+    "continent": "AN",
+    "capital": "",
+    "currency": [
+      "NOK"
+    ],
+    "languages": [
+      "no",
+      "nb",
+      "nn"
+    ]
+  },
+  "BW": {
+    "name": "Botswana",
+    "native": "Botswana",
+    "phone": [
+      267
+    ],
+    "continent": "AF",
+    "capital": "Gaborone",
+    "currency": [
+      "BWP"
+    ],
+    "languages": [
+      "en",
+      "tn"
+    ]
+  },
+  "BY": {
+    "name": "Belarus",
+    "native": "Белару́сь",
+    "phone": [
+      375
+    ],
+    "continent": "EU",
+    "capital": "Minsk",
+    "currency": [
+      "BYN"
+    ],
+    "languages": [
+      "be",
+      "ru"
+    ]
+  },
+  "BZ": {
+    "name": "Belize",
+    "native": "Belize",
+    "phone": [
+      501
+    ],
+    "continent": "NA",
+    "capital": "Belmopan",
+    "currency": [
+      "BZD"
+    ],
+    "languages": [
+      "en",
+      "es"
+    ]
+  },
+  "CA": {
+    "name": "Canada",
+    "native": "Canada",
+    "phone": [
+      1
+    ],
+    "continent": "NA",
+    "capital": "Ottawa",
+    "currency": [
+      "CAD"
+    ],
+    "languages": [
+      "en",
+      "fr"
+    ]
+  },
+  "CC": {
+    "name": "Cocos [Keeling] Islands",
+    "native": "Cocos (Keeling) Islands",
+    "phone": [
+      61
+    ],
+    "continent": "AS",
+    "capital": "West Island",
+    "currency": [
+      "AUD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "CD": {
+    "name": "Democratic Republic of the Congo",
+    "native": "République démocratique du Congo",
+    "phone": [
+      243
+    ],
+    "continent": "AF",
+    "capital": "Kinshasa",
+    "currency": [
+      "CDF"
+    ],
+    "languages": [
+      "fr",
+      "ln",
+      "kg",
+      "sw",
+      "lu"
+    ]
+  },
+  "CF": {
+    "name": "Central African Republic",
+    "native": "Ködörösêse tî Bêafrîka",
+    "phone": [
+      236
+    ],
+    "continent": "AF",
+    "capital": "Bangui",
+    "currency": [
+      "XAF"
+    ],
+    "languages": [
+      "fr",
+      "sg"
+    ]
+  },
+  "CG": {
+    "name": "Republic of the Congo",
+    "native": "République du Congo",
+    "phone": [
+      242
+    ],
+    "continent": "AF",
+    "capital": "Brazzaville",
+    "currency": [
+      "XAF"
+    ],
+    "languages": [
+      "fr",
+      "ln"
+    ]
+  },
+  "CH": {
+    "name": "Switzerland",
+    "native": "Schweiz",
+    "phone": [
+      41
+    ],
+    "continent": "EU",
+    "capital": "Bern",
+    "currency": [
+      "CHE",
+      "CHF",
+      "CHW"
+    ],
+    "languages": [
+      "de",
+      "fr",
+      "it"
+    ]
+  },
+  "CI": {
+    "name": "Ivory Coast",
+    "native": "Côte d'Ivoire",
+    "phone": [
+      225
+    ],
+    "continent": "AF",
+    "capital": "Yamoussoukro",
+    "currency": [
+      "XOF"
+    ],
+    "languages": [
+      "fr"
+    ]
+  },
+  "CK": {
+    "name": "Cook Islands",
+    "native": "Cook Islands",
+    "phone": [
+      682
+    ],
+    "continent": "OC",
+    "capital": "Avarua",
+    "currency": [
+      "NZD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "CL": {
+    "name": "Chile",
+    "native": "Chile",
+    "phone": [
+      56
+    ],
+    "continent": "SA",
+    "capital": "Santiago",
+    "currency": [
+      "CLF",
+      "CLP"
+    ],
+    "languages": [
+      "es"
+    ]
+  },
+  "CM": {
+    "name": "Cameroon",
+    "native": "Cameroon",
+    "phone": [
+      237
+    ],
+    "continent": "AF",
+    "capital": "Yaoundé",
+    "currency": [
+      "XAF"
+    ],
+    "languages": [
+      "en",
+      "fr"
+    ]
+  },
+  "CN": {
+    "name": "China",
+    "native": "中国",
+    "phone": [
+      86
+    ],
+    "continent": "AS",
+    "capital": "Beijing",
+    "currency": [
+      "CNY"
+    ],
+    "languages": [
+      "zh"
+    ]
+  },
+  "CO": {
+    "name": "Colombia",
+    "native": "Colombia",
+    "phone": [
+      57
+    ],
+    "continent": "SA",
+    "capital": "Bogotá",
+    "currency": [
+      "COP"
+    ],
+    "languages": [
+      "es"
+    ]
+  },
+  "CR": {
+    "name": "Costa Rica",
+    "native": "Costa Rica",
+    "phone": [
+      506
+    ],
+    "continent": "NA",
+    "capital": "San José",
+    "currency": [
+      "CRC"
+    ],
+    "languages": [
+      "es"
+    ]
+  },
+  "CU": {
+    "name": "Cuba",
+    "native": "Cuba",
+    "phone": [
+      53
+    ],
+    "continent": "NA",
+    "capital": "Havana",
+    "currency": [
+      "CUC",
+      "CUP"
+    ],
+    "languages": [
+      "es"
+    ]
+  },
+  "CV": {
+    "name": "Cape Verde",
+    "native": "Cabo Verde",
+    "phone": [
+      238
+    ],
+    "continent": "AF",
+    "capital": "Praia",
+    "currency": [
+      "CVE"
+    ],
+    "languages": [
+      "pt"
+    ]
+  },
+  "CW": {
+    "name": "Curacao",
+    "native": "Curaçao",
+    "phone": [
+      5999
+    ],
+    "continent": "NA",
+    "capital": "Willemstad",
+    "currency": [
+      "ANG"
+    ],
+    "languages": [
+      "nl",
+      "pa",
+      "en"
+    ]
+  },
+  "CX": {
+    "name": "Christmas Island",
+    "native": "Christmas Island",
+    "phone": [
+      61
+    ],
+    "continent": "AS",
+    "capital": "Flying Fish Cove",
+    "currency": [
+      "AUD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "CY": {
+    "name": "Cyprus",
+    "native": "Κύπρος",
+    "phone": [
+      357
+    ],
+    "continent": "EU",
+    "capital": "Nicosia",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "el",
+      "tr",
+      "hy"
+    ]
+  },
+  "CZ": {
+    "name": "Czech Republic",
+    "native": "Česká republika",
+    "phone": [
+      420
+    ],
+    "continent": "EU",
+    "capital": "Prague",
+    "currency": [
+      "CZK"
+    ],
+    "languages": [
+      "cs",
+      "sk"
+    ]
+  },
+  "DE": {
+    "name": "Germany",
+    "native": "Deutschland",
+    "phone": [
+      49
+    ],
+    "continent": "EU",
+    "capital": "Berlin",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "de"
+    ]
+  },
+  "DJ": {
+    "name": "Djibouti",
+    "native": "Djibouti",
+    "phone": [
+      253
+    ],
+    "continent": "AF",
+    "capital": "Djibouti",
+    "currency": [
+      "DJF"
+    ],
+    "languages": [
+      "fr",
+      "ar"
+    ]
+  },
+  "DK": {
+    "name": "Denmark",
+    "native": "Danmark",
+    "phone": [
+      45
+    ],
+    "continent": "EU",
+    "continents": [
+      "EU",
+      "NA"
+    ],
+    "capital": "Copenhagen",
+    "currency": [
+      "DKK"
+    ],
+    "languages": [
+      "da"
+    ]
+  },
+  "DM": {
+    "name": "Dominica",
+    "native": "Dominica",
+    "phone": [
+      1767
+    ],
+    "continent": "NA",
+    "capital": "Roseau",
+    "currency": [
+      "XCD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "DO": {
+    "name": "Dominican Republic",
+    "native": "República Dominicana",
+    "phone": [
+      1809,
+      1829,
+      1849
+    ],
+    "continent": "NA",
+    "capital": "Santo Domingo",
+    "currency": [
+      "DOP"
+    ],
+    "languages": [
+      "es"
+    ]
+  },
+  "DZ": {
+    "name": "Algeria",
+    "native": "الجزائر",
+    "phone": [
+      213
+    ],
+    "continent": "AF",
+    "capital": "Algiers",
+    "currency": [
+      "DZD"
+    ],
+    "languages": [
+      "ar"
+    ]
+  },
+  "EC": {
+    "name": "Ecuador",
+    "native": "Ecuador",
+    "phone": [
+      593
+    ],
+    "continent": "SA",
+    "capital": "Quito",
+    "currency": [
+      "USD"
+    ],
+    "languages": [
+      "es"
+    ]
+  },
+  "EE": {
+    "name": "Estonia",
+    "native": "Eesti",
+    "phone": [
+      372
+    ],
+    "continent": "EU",
+    "capital": "Tallinn",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "et"
+    ]
+  },
+  "EG": {
+    "name": "Egypt",
+    "native": "مصر‎",
+    "phone": [
+      20
+    ],
+    "continent": "AF",
+    "continents": [
+      "AF",
+      "AS"
+    ],
+    "capital": "Cairo",
+    "currency": [
+      "EGP"
+    ],
+    "languages": [
+      "ar"
+    ]
+  },
+  "EH": {
+    "name": "Western Sahara",
+    "native": "الصحراء الغربية",
+    "phone": [
+      212
+    ],
+    "continent": "AF",
+    "capital": "El Aaiún",
+    "currency": [
+      "MAD",
+      "DZD",
+      "MRU"
+    ],
+    "languages": [
+      "es"
+    ]
+  },
+  "ER": {
+    "name": "Eritrea",
+    "native": "ኤርትራ",
+    "phone": [
+      291
+    ],
+    "continent": "AF",
+    "capital": "Asmara",
+    "currency": [
+      "ERN"
+    ],
+    "languages": [
+      "ti",
+      "ar",
+      "en"
+    ]
+  },
+  "ES": {
+    "name": "Spain",
+    "native": "España",
+    "phone": [
+      34
+    ],
+    "continent": "EU",
+    "capital": "Madrid",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "es",
+      "eu",
+      "ca",
+      "gl",
+      "oc"
+    ]
+  },
+  "ET": {
+    "name": "Ethiopia",
+    "native": "ኢትዮጵያ",
+    "phone": [
+      251
+    ],
+    "continent": "AF",
+    "capital": "Addis Ababa",
+    "currency": [
+      "ETB"
+    ],
+    "languages": [
+      "am"
+    ]
+  },
+  "FI": {
+    "name": "Finland",
+    "native": "Suomi",
+    "phone": [
+      358
+    ],
+    "continent": "EU",
+    "capital": "Helsinki",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "fi",
+      "sv"
+    ]
+  },
+  "FJ": {
+    "name": "Fiji",
+    "native": "Fiji",
+    "phone": [
+      679
+    ],
+    "continent": "OC",
+    "capital": "Suva",
+    "currency": [
+      "FJD"
+    ],
+    "languages": [
+      "en",
+      "fj",
+      "hi",
+      "ur"
+    ]
+  },
+  "FK": {
+    "name": "Falkland Islands",
+    "native": "Falkland Islands",
+    "phone": [
+      500
+    ],
+    "continent": "SA",
+    "capital": "Stanley",
+    "currency": [
+      "FKP"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "FM": {
+    "name": "Micronesia",
+    "native": "Micronesia",
+    "phone": [
+      691
+    ],
+    "continent": "OC",
+    "capital": "Palikir",
+    "currency": [
+      "USD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "FO": {
+    "name": "Faroe Islands",
+    "native": "Føroyar",
+    "phone": [
+      298
+    ],
+    "continent": "EU",
+    "capital": "Tórshavn",
+    "currency": [
+      "DKK"
+    ],
+    "languages": [
+      "fo"
+    ]
+  },
+  "FR": {
+    "name": "France",
+    "native": "France",
+    "phone": [
+      33
+    ],
+    "continent": "EU",
+    "capital": "Paris",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "fr"
+    ]
+  },
+  "GA": {
+    "name": "Gabon",
+    "native": "Gabon",
+    "phone": [
+      241
+    ],
+    "continent": "AF",
+    "capital": "Libreville",
+    "currency": [
+      "XAF"
+    ],
+    "languages": [
+      "fr"
+    ]
+  },
+  "GB": {
+    "name": "United Kingdom",
+    "native": "United Kingdom",
+    "phone": [
+      44
+    ],
+    "continent": "EU",
+    "capital": "London",
+    "currency": [
+      "GBP"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "GD": {
+    "name": "Grenada",
+    "native": "Grenada",
+    "phone": [
+      1473
+    ],
+    "continent": "NA",
+    "capital": "St. George's",
+    "currency": [
+      "XCD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "GE": {
+    "name": "Georgia",
+    "native": "საქართველო",
+    "phone": [
+      995
+    ],
+    "continent": "AS",
+    "capital": "Tbilisi",
+    "currency": [
+      "GEL"
+    ],
+    "languages": [
+      "ka"
+    ]
+  },
+  "GF": {
+    "name": "French Guiana",
+    "native": "Guyane française",
+    "phone": [
+      594
+    ],
+    "continent": "SA",
+    "capital": "Cayenne",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "fr"
+    ]
+  },
+  "GG": {
+    "name": "Guernsey",
+    "native": "Guernsey",
+    "phone": [
+      44
+    ],
+    "continent": "EU",
+    "capital": "St. Peter Port",
+    "currency": [
+      "GBP"
+    ],
+    "languages": [
+      "en",
+      "fr"
+    ]
+  },
+  "GH": {
+    "name": "Ghana",
+    "native": "Ghana",
+    "phone": [
+      233
+    ],
+    "continent": "AF",
+    "capital": "Accra",
+    "currency": [
+      "GHS"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "GI": {
+    "name": "Gibraltar",
+    "native": "Gibraltar",
+    "phone": [
+      350
+    ],
+    "continent": "EU",
+    "capital": "Gibraltar",
+    "currency": [
+      "GIP"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "GL": {
+    "name": "Greenland",
+    "native": "Kalaallit Nunaat",
+    "phone": [
+      299
+    ],
+    "continent": "NA",
+    "capital": "Nuuk",
+    "currency": [
+      "DKK"
+    ],
+    "languages": [
+      "kl"
+    ]
+  },
+  "GM": {
+    "name": "Gambia",
+    "native": "Gambia",
+    "phone": [
+      220
+    ],
+    "continent": "AF",
+    "capital": "Banjul",
+    "currency": [
+      "GMD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "GN": {
+    "name": "Guinea",
+    "native": "Guinée",
+    "phone": [
+      224
+    ],
+    "continent": "AF",
+    "capital": "Conakry",
+    "currency": [
+      "GNF"
+    ],
+    "languages": [
+      "fr",
+      "ff"
+    ]
+  },
+  "GP": {
+    "name": "Guadeloupe",
+    "native": "Guadeloupe",
+    "phone": [
+      590
+    ],
+    "continent": "NA",
+    "capital": "Basse-Terre",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "fr"
+    ]
+  },
+  "GQ": {
+    "name": "Equatorial Guinea",
+    "native": "Guinea Ecuatorial",
+    "phone": [
+      240
+    ],
+    "continent": "AF",
+    "capital": "Malabo",
+    "currency": [
+      "XAF"
+    ],
+    "languages": [
+      "es",
+      "fr"
+    ]
+  },
+  "GR": {
+    "name": "Greece",
+    "native": "Ελλάδα",
+    "phone": [
+      30
+    ],
+    "continent": "EU",
+    "capital": "Athens",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "el"
+    ]
+  },
+  "GS": {
+    "name": "South Georgia and the South Sandwich Islands",
+    "native": "South Georgia",
+    "phone": [
+      500
+    ],
+    "continent": "AN",
+    "capital": "King Edward Point",
+    "currency": [
+      "GBP"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "GT": {
+    "name": "Guatemala",
+    "native": "Guatemala",
+    "phone": [
+      502
+    ],
+    "continent": "NA",
+    "capital": "Guatemala City",
+    "currency": [
+      "GTQ"
+    ],
+    "languages": [
+      "es"
+    ]
+  },
+  "GU": {
+    "name": "Guam",
+    "native": "Guam",
+    "phone": [
+      1671
+    ],
+    "continent": "OC",
+    "capital": "Hagåtña",
+    "currency": [
+      "USD"
+    ],
+    "languages": [
+      "en",
+      "ch",
+      "es"
+    ]
+  },
+  "GW": {
+    "name": "Guinea-Bissau",
+    "native": "Guiné-Bissau",
+    "phone": [
+      245
+    ],
+    "continent": "AF",
+    "capital": "Bissau",
+    "currency": [
+      "XOF"
+    ],
+    "languages": [
+      "pt"
+    ]
+  },
+  "GY": {
+    "name": "Guyana",
+    "native": "Guyana",
+    "phone": [
+      592
+    ],
+    "continent": "SA",
+    "capital": "Georgetown",
+    "currency": [
+      "GYD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "HK": {
+    "name": "Hong Kong",
+    "native": "香港",
+    "phone": [
+      852
+    ],
+    "continent": "AS",
+    "capital": "City of Victoria",
+    "currency": [
+      "HKD"
+    ],
+    "languages": [
+      "zh",
+      "en"
+    ]
+  },
+  "HM": {
+    "name": "Heard Island and McDonald Islands",
+    "native": "Heard Island and McDonald Islands",
+    "phone": [
+      61
+    ],
+    "continent": "AN",
+    "capital": "",
+    "currency": [
+      "AUD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "HN": {
+    "name": "Honduras",
+    "native": "Honduras",
+    "phone": [
+      504
+    ],
+    "continent": "NA",
+    "capital": "Tegucigalpa",
+    "currency": [
+      "HNL"
+    ],
+    "languages": [
+      "es"
+    ]
+  },
+  "HR": {
+    "name": "Croatia",
+    "native": "Hrvatska",
+    "phone": [
+      385
+    ],
+    "continent": "EU",
+    "capital": "Zagreb",
+    "currency": [
+      "HRK"
+    ],
+    "languages": [
+      "hr"
+    ]
+  },
+  "HT": {
+    "name": "Haiti",
+    "native": "Haïti",
+    "phone": [
+      509
+    ],
+    "continent": "NA",
+    "capital": "Port-au-Prince",
+    "currency": [
+      "HTG",
+      "USD"
+    ],
+    "languages": [
+      "fr",
+      "ht"
+    ]
+  },
+  "HU": {
+    "name": "Hungary",
+    "native": "Magyarország",
+    "phone": [
+      36
+    ],
+    "continent": "EU",
+    "capital": "Budapest",
+    "currency": [
+      "HUF"
+    ],
+    "languages": [
+      "hu"
+    ]
+  },
+  "ID": {
+    "name": "Indonesia",
+    "native": "Indonesia",
+    "phone": [
+      62
+    ],
+    "continent": "AS",
+    "capital": "Jakarta",
+    "currency": [
+      "IDR"
+    ],
+    "languages": [
+      "id"
+    ]
+  },
+  "IE": {
+    "name": "Ireland",
+    "native": "Éire",
+    "phone": [
+      353
+    ],
+    "continent": "EU",
+    "capital": "Dublin",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "ga",
+      "en"
+    ]
+  },
+  "IL": {
+    "name": "Israel",
+    "native": "יִשְׂרָאֵל",
+    "phone": [
+      972
+    ],
+    "continent": "AS",
+    "capital": "Jerusalem",
+    "currency": [
+      "ILS"
+    ],
+    "languages": [
+      "he",
+      "ar"
+    ]
+  },
+  "IM": {
+    "name": "Isle of Man",
+    "native": "Isle of Man",
+    "phone": [
+      44
+    ],
+    "continent": "EU",
+    "capital": "Douglas",
+    "currency": [
+      "GBP"
+    ],
+    "languages": [
+      "en",
+      "gv"
+    ]
+  },
+  "IN": {
+    "name": "India",
+    "native": "भारत",
+    "phone": [
+      91
+    ],
+    "continent": "AS",
+    "capital": "New Delhi",
+    "currency": [
+      "INR"
+    ],
+    "languages": [
+      "hi",
+      "en"
+    ]
+  },
+  "IO": {
+    "name": "British Indian Ocean Territory",
+    "native": "British Indian Ocean Territory",
+    "phone": [
+      246
+    ],
+    "continent": "AS",
+    "capital": "Diego Garcia",
+    "currency": [
+      "USD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "IQ": {
+    "name": "Iraq",
+    "native": "العراق",
+    "phone": [
+      964
+    ],
+    "continent": "AS",
+    "capital": "Baghdad",
+    "currency": [
+      "IQD"
+    ],
+    "languages": [
+      "ar",
+      "ku"
+    ]
+  },
+  "IR": {
+    "name": "Iran",
+    "native": "ایران",
+    "phone": [
+      98
+    ],
+    "continent": "AS",
+    "capital": "Tehran",
+    "currency": [
+      "IRR"
+    ],
+    "languages": [
+      "fa"
+    ]
+  },
+  "IS": {
+    "name": "Iceland",
+    "native": "Ísland",
+    "phone": [
+      354
+    ],
+    "continent": "EU",
+    "capital": "Reykjavik",
+    "currency": [
+      "ISK"
+    ],
+    "languages": [
+      "is"
+    ]
+  },
+  "IT": {
+    "name": "Italy",
+    "native": "Italia",
+    "phone": [
+      39
+    ],
+    "continent": "EU",
+    "capital": "Rome",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "it"
+    ]
+  },
+  "JE": {
+    "name": "Jersey",
+    "native": "Jersey",
+    "phone": [
+      44
+    ],
+    "continent": "EU",
+    "capital": "Saint Helier",
+    "currency": [
+      "GBP"
+    ],
+    "languages": [
+      "en",
+      "fr"
+    ]
+  },
+  "JM": {
+    "name": "Jamaica",
+    "native": "Jamaica",
+    "phone": [
+      1876
+    ],
+    "continent": "NA",
+    "capital": "Kingston",
+    "currency": [
+      "JMD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "JO": {
+    "name": "Jordan",
+    "native": "الأردن",
+    "phone": [
+      962
+    ],
+    "continent": "AS",
+    "capital": "Amman",
+    "currency": [
+      "JOD"
+    ],
+    "languages": [
+      "ar"
+    ]
+  },
+  "JP": {
+    "name": "Japan",
+    "native": "日本",
+    "phone": [
+      81
+    ],
+    "continent": "AS",
+    "capital": "Tokyo",
+    "currency": [
+      "JPY"
+    ],
+    "languages": [
+      "ja"
+    ]
+  },
+  "KE": {
+    "name": "Kenya",
+    "native": "Kenya",
+    "phone": [
+      254
+    ],
+    "continent": "AF",
+    "capital": "Nairobi",
+    "currency": [
+      "KES"
+    ],
+    "languages": [
+      "en",
+      "sw"
+    ]
+  },
+  "KG": {
+    "name": "Kyrgyzstan",
+    "native": "Кыргызстан",
+    "phone": [
+      996
+    ],
+    "continent": "AS",
+    "capital": "Bishkek",
+    "currency": [
+      "KGS"
+    ],
+    "languages": [
+      "ky",
+      "ru"
+    ]
+  },
+  "KH": {
+    "name": "Cambodia",
+    "native": "Kâmpŭchéa",
+    "phone": [
+      855
+    ],
+    "continent": "AS",
+    "capital": "Phnom Penh",
+    "currency": [
+      "KHR"
+    ],
+    "languages": [
+      "km"
+    ]
+  },
+  "KI": {
+    "name": "Kiribati",
+    "native": "Kiribati",
+    "phone": [
+      686
+    ],
+    "continent": "OC",
+    "capital": "South Tarawa",
+    "currency": [
+      "AUD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "KM": {
+    "name": "Comoros",
+    "native": "Komori",
+    "phone": [
+      269
+    ],
+    "continent": "AF",
+    "capital": "Moroni",
+    "currency": [
+      "KMF"
+    ],
+    "languages": [
+      "ar",
+      "fr"
+    ]
+  },
+  "KN": {
+    "name": "Saint Kitts and Nevis",
+    "native": "Saint Kitts and Nevis",
+    "phone": [
+      1869
+    ],
+    "continent": "NA",
+    "capital": "Basseterre",
+    "currency": [
+      "XCD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "KP": {
+    "name": "North Korea",
+    "native": "북한",
+    "phone": [
+      850
+    ],
+    "continent": "AS",
+    "capital": "Pyongyang",
+    "currency": [
+      "KPW"
+    ],
+    "languages": [
+      "ko"
+    ]
+  },
+  "KR": {
+    "name": "South Korea",
+    "native": "대한민국",
+    "phone": [
+      82
+    ],
+    "continent": "AS",
+    "capital": "Seoul",
+    "currency": [
+      "KRW"
+    ],
+    "languages": [
+      "ko"
+    ]
+  },
+  "KW": {
+    "name": "Kuwait",
+    "native": "الكويت",
+    "phone": [
+      965
+    ],
+    "continent": "AS",
+    "capital": "Kuwait City",
+    "currency": [
+      "KWD"
+    ],
+    "languages": [
+      "ar"
+    ]
+  },
+  "KY": {
+    "name": "Cayman Islands",
+    "native": "Cayman Islands",
+    "phone": [
+      1345
+    ],
+    "continent": "NA",
+    "capital": "George Town",
+    "currency": [
+      "KYD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "KZ": {
+    "name": "Kazakhstan",
+    "native": "Қазақстан",
+    "phone": [
+      76,
+      77
+    ],
+    "continent": "AS",
+    "continents": [
+      "AS",
+      "EU"
+    ],
+    "capital": "Astana",
+    "currency": [
+      "KZT"
+    ],
+    "languages": [
+      "kk",
+      "ru"
+    ]
+  },
+  "LA": {
+    "name": "Laos",
+    "native": "ສປປລາວ",
+    "phone": [
+      856
+    ],
+    "continent": "AS",
+    "capital": "Vientiane",
+    "currency": [
+      "LAK"
+    ],
+    "languages": [
+      "lo"
+    ]
+  },
+  "LB": {
+    "name": "Lebanon",
+    "native": "لبنان",
+    "phone": [
+      961
+    ],
+    "continent": "AS",
+    "capital": "Beirut",
+    "currency": [
+      "LBP"
+    ],
+    "languages": [
+      "ar",
+      "fr"
+    ]
+  },
+  "LC": {
+    "name": "Saint Lucia",
+    "native": "Saint Lucia",
+    "phone": [
+      1758
+    ],
+    "continent": "NA",
+    "capital": "Castries",
+    "currency": [
+      "XCD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "LI": {
+    "name": "Liechtenstein",
+    "native": "Liechtenstein",
+    "phone": [
+      423
+    ],
+    "continent": "EU",
+    "capital": "Vaduz",
+    "currency": [
+      "CHF"
+    ],
+    "languages": [
+      "de"
+    ]
+  },
+  "LK": {
+    "name": "Sri Lanka",
+    "native": "śrī laṃkāva",
+    "phone": [
+      94
+    ],
+    "continent": "AS",
+    "capital": "Colombo",
+    "currency": [
+      "LKR"
+    ],
+    "languages": [
+      "si",
+      "ta"
+    ]
+  },
+  "LR": {
+    "name": "Liberia",
+    "native": "Liberia",
+    "phone": [
+      231
+    ],
+    "continent": "AF",
+    "capital": "Monrovia",
+    "currency": [
+      "LRD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "LS": {
+    "name": "Lesotho",
+    "native": "Lesotho",
+    "phone": [
+      266
+    ],
+    "continent": "AF",
+    "capital": "Maseru",
+    "currency": [
+      "LSL",
+      "ZAR"
+    ],
+    "languages": [
+      "en",
+      "st"
+    ]
+  },
+  "LT": {
+    "name": "Lithuania",
+    "native": "Lietuva",
+    "phone": [
+      370
+    ],
+    "continent": "EU",
+    "capital": "Vilnius",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "lt"
+    ]
+  },
+  "LU": {
+    "name": "Luxembourg",
+    "native": "Luxembourg",
+    "phone": [
+      352
+    ],
+    "continent": "EU",
+    "capital": "Luxembourg",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "fr",
+      "de",
+      "lb"
+    ]
+  },
+  "LV": {
+    "name": "Latvia",
+    "native": "Latvija",
+    "phone": [
+      371
+    ],
+    "continent": "EU",
+    "capital": "Riga",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "lv"
+    ]
+  },
+  "LY": {
+    "name": "Libya",
+    "native": "‏ليبيا",
+    "phone": [
+      218
+    ],
+    "continent": "AF",
+    "capital": "Tripoli",
+    "currency": [
+      "LYD"
+    ],
+    "languages": [
+      "ar"
+    ]
+  },
+  "MA": {
+    "name": "Morocco",
+    "native": "المغرب",
+    "phone": [
+      212
+    ],
+    "continent": "AF",
+    "capital": "Rabat",
+    "currency": [
+      "MAD"
+    ],
+    "languages": [
+      "ar"
+    ]
+  },
+  "MC": {
+    "name": "Monaco",
+    "native": "Monaco",
+    "phone": [
+      377
+    ],
+    "continent": "EU",
+    "capital": "Monaco",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "fr"
+    ]
+  },
+  "MD": {
+    "name": "Moldova",
+    "native": "Moldova",
+    "phone": [
+      373
+    ],
+    "continent": "EU",
+    "capital": "Chișinău",
+    "currency": [
+      "MDL"
+    ],
+    "languages": [
+      "ro"
+    ]
+  },
+  "ME": {
+    "name": "Montenegro",
+    "native": "Црна Гора",
+    "phone": [
+      382
+    ],
+    "continent": "EU",
+    "capital": "Podgorica",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "sr",
+      "bs",
+      "sq",
+      "hr"
+    ]
+  },
+  "MF": {
+    "name": "Saint Martin",
+    "native": "Saint-Martin",
+    "phone": [
+      590
+    ],
+    "continent": "NA",
+    "capital": "Marigot",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "en",
+      "fr",
+      "nl"
+    ]
+  },
+  "MG": {
+    "name": "Madagascar",
+    "native": "Madagasikara",
+    "phone": [
+      261
+    ],
+    "continent": "AF",
+    "capital": "Antananarivo",
+    "currency": [
+      "MGA"
+    ],
+    "languages": [
+      "fr",
+      "mg"
+    ]
+  },
+  "MH": {
+    "name": "Marshall Islands",
+    "native": "M̧ajeļ",
+    "phone": [
+      692
+    ],
+    "continent": "OC",
+    "capital": "Majuro",
+    "currency": [
+      "USD"
+    ],
+    "languages": [
+      "en",
+      "mh"
+    ]
+  },
+  "MK": {
+    "name": "North Macedonia",
+    "native": "Северна Македонија",
+    "phone": [
+      389
+    ],
+    "continent": "EU",
+    "capital": "Skopje",
+    "currency": [
+      "MKD"
+    ],
+    "languages": [
+      "mk"
+    ]
+  },
+  "ML": {
+    "name": "Mali",
+    "native": "Mali",
+    "phone": [
+      223
+    ],
+    "continent": "AF",
+    "capital": "Bamako",
+    "currency": [
+      "XOF"
+    ],
+    "languages": [
+      "fr"
+    ]
+  },
+  "MM": {
+    "name": "Myanmar [Burma]",
+    "native": "မြန်မာ",
+    "phone": [
+      95
+    ],
+    "continent": "AS",
+    "capital": "Naypyidaw",
+    "currency": [
+      "MMK"
+    ],
+    "languages": [
+      "my"
+    ]
+  },
+  "MN": {
+    "name": "Mongolia",
+    "native": "Монгол улс",
+    "phone": [
+      976
+    ],
+    "continent": "AS",
+    "capital": "Ulan Bator",
+    "currency": [
+      "MNT"
+    ],
+    "languages": [
+      "mn"
+    ]
+  },
+  "MO": {
+    "name": "Macao",
+    "native": "澳門",
+    "phone": [
+      853
+    ],
+    "continent": "AS",
+    "capital": "",
+    "currency": [
+      "MOP"
+    ],
+    "languages": [
+      "zh",
+      "pt"
+    ]
+  },
+  "MP": {
+    "name": "Northern Mariana Islands",
+    "native": "Northern Mariana Islands",
+    "phone": [
+      1670
+    ],
+    "continent": "OC",
+    "capital": "Saipan",
+    "currency": [
+      "USD"
+    ],
+    "languages": [
+      "en",
+      "ch"
+    ]
+  },
+  "MQ": {
+    "name": "Martinique",
+    "native": "Martinique",
+    "phone": [
+      596
+    ],
+    "continent": "NA",
+    "capital": "Fort-de-France",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "fr"
+    ]
+  },
+  "MR": {
+    "name": "Mauritania",
+    "native": "موريتانيا",
+    "phone": [
+      222
+    ],
+    "continent": "AF",
+    "capital": "Nouakchott",
+    "currency": [
+      "MRU"
+    ],
+    "languages": [
+      "ar"
+    ]
+  },
+  "MS": {
+    "name": "Montserrat",
+    "native": "Montserrat",
+    "phone": [
+      1664
+    ],
+    "continent": "NA",
+    "capital": "Plymouth",
+    "currency": [
+      "XCD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "MT": {
+    "name": "Malta",
+    "native": "Malta",
+    "phone": [
+      356
+    ],
+    "continent": "EU",
+    "capital": "Valletta",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "mt",
+      "en"
+    ]
+  },
+  "MU": {
+    "name": "Mauritius",
+    "native": "Maurice",
+    "phone": [
+      230
+    ],
+    "continent": "AF",
+    "capital": "Port Louis",
+    "currency": [
+      "MUR"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "MV": {
+    "name": "Maldives",
+    "native": "Maldives",
+    "phone": [
+      960
+    ],
+    "continent": "AS",
+    "capital": "Malé",
+    "currency": [
+      "MVR"
+    ],
+    "languages": [
+      "dv"
+    ]
+  },
+  "MW": {
+    "name": "Malawi",
+    "native": "Malawi",
+    "phone": [
+      265
+    ],
+    "continent": "AF",
+    "capital": "Lilongwe",
+    "currency": [
+      "MWK"
+    ],
+    "languages": [
+      "en",
+      "ny"
+    ]
+  },
+  "MX": {
+    "name": "Mexico",
+    "native": "México",
+    "phone": [
+      52
+    ],
+    "continent": "NA",
+    "capital": "Mexico City",
+    "currency": [
+      "MXN"
+    ],
+    "languages": [
+      "es"
+    ]
+  },
+  "MY": {
+    "name": "Malaysia",
+    "native": "Malaysia",
+    "phone": [
+      60
+    ],
+    "continent": "AS",
+    "capital": "Kuala Lumpur",
+    "currency": [
+      "MYR"
+    ],
+    "languages": [
+      "ms"
+    ]
+  },
+  "MZ": {
+    "name": "Mozambique",
+    "native": "Moçambique",
+    "phone": [
+      258
+    ],
+    "continent": "AF",
+    "capital": "Maputo",
+    "currency": [
+      "MZN"
+    ],
+    "languages": [
+      "pt"
+    ]
+  },
+  "NA": {
+    "name": "Namibia",
+    "native": "Namibia",
+    "phone": [
+      264
+    ],
+    "continent": "AF",
+    "capital": "Windhoek",
+    "currency": [
+      "NAD",
+      "ZAR"
+    ],
+    "languages": [
+      "en",
+      "af"
+    ]
+  },
+  "NC": {
+    "name": "New Caledonia",
+    "native": "Nouvelle-Calédonie",
+    "phone": [
+      687
+    ],
+    "continent": "OC",
+    "capital": "Nouméa",
+    "currency": [
+      "XPF"
+    ],
+    "languages": [
+      "fr"
+    ]
+  },
+  "NE": {
+    "name": "Niger",
+    "native": "Niger",
+    "phone": [
+      227
+    ],
+    "continent": "AF",
+    "capital": "Niamey",
+    "currency": [
+      "XOF"
+    ],
+    "languages": [
+      "fr"
+    ]
+  },
+  "NF": {
+    "name": "Norfolk Island",
+    "native": "Norfolk Island",
+    "phone": [
+      672
+    ],
+    "continent": "OC",
+    "capital": "Kingston",
+    "currency": [
+      "AUD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "NG": {
+    "name": "Nigeria",
+    "native": "Nigeria",
+    "phone": [
+      234
+    ],
+    "continent": "AF",
+    "capital": "Abuja",
+    "currency": [
+      "NGN"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "NI": {
+    "name": "Nicaragua",
+    "native": "Nicaragua",
+    "phone": [
+      505
+    ],
+    "continent": "NA",
+    "capital": "Managua",
+    "currency": [
+      "NIO"
+    ],
+    "languages": [
+      "es"
+    ]
+  },
+  "NL": {
+    "name": "Netherlands",
+    "native": "Nederland",
+    "phone": [
+      31
+    ],
+    "continent": "EU",
+    "capital": "Amsterdam",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "nl"
+    ]
+  },
+  "NO": {
+    "name": "Norway",
+    "native": "Norge",
+    "phone": [
+      47
+    ],
+    "continent": "EU",
+    "capital": "Oslo",
+    "currency": [
+      "NOK"
+    ],
+    "languages": [
+      "no",
+      "nb",
+      "nn"
+    ]
+  },
+  "NP": {
+    "name": "Nepal",
+    "native": "नपल",
+    "phone": [
+      977
+    ],
+    "continent": "AS",
+    "capital": "Kathmandu",
+    "currency": [
+      "NPR"
+    ],
+    "languages": [
+      "ne"
+    ]
+  },
+  "NR": {
+    "name": "Nauru",
+    "native": "Nauru",
+    "phone": [
+      674
+    ],
+    "continent": "OC",
+    "capital": "Yaren",
+    "currency": [
+      "AUD"
+    ],
+    "languages": [
+      "en",
+      "na"
+    ]
+  },
+  "NU": {
+    "name": "Niue",
+    "native": "Niuē",
+    "phone": [
+      683
+    ],
+    "continent": "OC",
+    "capital": "Alofi",
+    "currency": [
+      "NZD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "NZ": {
+    "name": "New Zealand",
+    "native": "New Zealand",
+    "phone": [
+      64
+    ],
+    "continent": "OC",
+    "capital": "Wellington",
+    "currency": [
+      "NZD"
+    ],
+    "languages": [
+      "en",
+      "mi"
+    ]
+  },
+  "OM": {
+    "name": "Oman",
+    "native": "عمان",
+    "phone": [
+      968
+    ],
+    "continent": "AS",
+    "capital": "Muscat",
+    "currency": [
+      "OMR"
+    ],
+    "languages": [
+      "ar"
+    ]
+  },
+  "PA": {
+    "name": "Panama",
+    "native": "Panamá",
+    "phone": [
+      507
+    ],
+    "continent": "NA",
+    "capital": "Panama City",
+    "currency": [
+      "PAB",
+      "USD"
+    ],
+    "languages": [
+      "es"
+    ]
+  },
+  "PE": {
+    "name": "Peru",
+    "native": "Perú",
+    "phone": [
+      51
+    ],
+    "continent": "SA",
+    "capital": "Lima",
+    "currency": [
+      "PEN"
+    ],
+    "languages": [
+      "es"
+    ]
+  },
+  "PF": {
+    "name": "French Polynesia",
+    "native": "Polynésie française",
+    "phone": [
+      689
+    ],
+    "continent": "OC",
+    "capital": "Papeetē",
+    "currency": [
+      "XPF"
+    ],
+    "languages": [
+      "fr"
+    ]
+  },
+  "PG": {
+    "name": "Papua New Guinea",
+    "native": "Papua Niugini",
+    "phone": [
+      675
+    ],
+    "continent": "OC",
+    "capital": "Port Moresby",
+    "currency": [
+      "PGK"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "PH": {
+    "name": "Philippines",
+    "native": "Pilipinas",
+    "phone": [
+      63
+    ],
+    "continent": "AS",
+    "capital": "Manila",
+    "currency": [
+      "PHP"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "PK": {
+    "name": "Pakistan",
+    "native": "Pakistan",
+    "phone": [
+      92
+    ],
+    "continent": "AS",
+    "capital": "Islamabad",
+    "currency": [
+      "PKR"
+    ],
+    "languages": [
+      "en",
+      "ur"
+    ]
+  },
+  "PL": {
+    "name": "Poland",
+    "native": "Polska",
+    "phone": [
+      48
+    ],
+    "continent": "EU",
+    "capital": "Warsaw",
+    "currency": [
+      "PLN"
+    ],
+    "languages": [
+      "pl"
+    ]
+  },
+  "PM": {
+    "name": "Saint Pierre and Miquelon",
+    "native": "Saint-Pierre-et-Miquelon",
+    "phone": [
+      508
+    ],
+    "continent": "NA",
+    "capital": "Saint-Pierre",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "fr"
+    ]
+  },
+  "PN": {
+    "name": "Pitcairn Islands",
+    "native": "Pitcairn Islands",
+    "phone": [
+      64
+    ],
+    "continent": "OC",
+    "capital": "Adamstown",
+    "currency": [
+      "NZD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "PR": {
+    "name": "Puerto Rico",
+    "native": "Puerto Rico",
+    "phone": [
+      1787,
+      1939
+    ],
+    "continent": "NA",
+    "capital": "San Juan",
+    "currency": [
+      "USD"
+    ],
+    "languages": [
+      "es",
+      "en"
+    ]
+  },
+  "PS": {
+    "name": "Palestine",
+    "native": "فلسطين",
+    "phone": [
+      970
+    ],
+    "continent": "AS",
+    "capital": "Ramallah",
+    "currency": [
+      "ILS"
+    ],
+    "languages": [
+      "ar"
+    ]
+  },
+  "PT": {
+    "name": "Portugal",
+    "native": "Portugal",
+    "phone": [
+      351
+    ],
+    "continent": "EU",
+    "capital": "Lisbon",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "pt"
+    ]
+  },
+  "PW": {
+    "name": "Palau",
+    "native": "Palau",
+    "phone": [
+      680
+    ],
+    "continent": "OC",
+    "capital": "Ngerulmud",
+    "currency": [
+      "USD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "PY": {
+    "name": "Paraguay",
+    "native": "Paraguay",
+    "phone": [
+      595
+    ],
+    "continent": "SA",
+    "capital": "Asunción",
+    "currency": [
+      "PYG"
+    ],
+    "languages": [
+      "es",
+      "gn"
+    ]
+  },
+  "QA": {
+    "name": "Qatar",
+    "native": "قطر",
+    "phone": [
+      974
+    ],
+    "continent": "AS",
+    "capital": "Doha",
+    "currency": [
+      "QAR"
+    ],
+    "languages": [
+      "ar"
+    ]
+  },
+  "RE": {
+    "name": "Réunion",
+    "native": "La Réunion",
+    "phone": [
+      262
+    ],
+    "continent": "AF",
+    "capital": "Saint-Denis",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "fr"
+    ]
+  },
+  "RO": {
+    "name": "Romania",
+    "native": "România",
+    "phone": [
+      40
+    ],
+    "continent": "EU",
+    "capital": "Bucharest",
+    "currency": [
+      "RON"
+    ],
+    "languages": [
+      "ro"
+    ]
+  },
+  "RS": {
+    "name": "Serbia",
+    "native": "Србија",
+    "phone": [
+      381
+    ],
+    "continent": "EU",
+    "capital": "Belgrade",
+    "currency": [
+      "RSD"
+    ],
+    "languages": [
+      "sr"
+    ]
+  },
+  "RU": {
+    "name": "Russia",
+    "native": "Россия",
+    "phone": [
+      7
+    ],
+    "continent": "EU",
+    "continents": [
+      "AS",
+      "EU"
+    ],
+    "capital": "Moscow",
+    "currency": [
+      "RUB"
+    ],
+    "languages": [
+      "ru"
+    ]
+  },
+  "RW": {
+    "name": "Rwanda",
+    "native": "Rwanda",
+    "phone": [
+      250
+    ],
+    "continent": "AF",
+    "capital": "Kigali",
+    "currency": [
+      "RWF"
+    ],
+    "languages": [
+      "rw",
+      "en",
+      "fr"
+    ]
+  },
+  "SA": {
+    "name": "Saudi Arabia",
+    "native": "العربية السعودية",
+    "phone": [
+      966
+    ],
+    "continent": "AS",
+    "capital": "Riyadh",
+    "currency": [
+      "SAR"
+    ],
+    "languages": [
+      "ar"
+    ]
+  },
+  "SB": {
+    "name": "Solomon Islands",
+    "native": "Solomon Islands",
+    "phone": [
+      677
+    ],
+    "continent": "OC",
+    "capital": "Honiara",
+    "currency": [
+      "SBD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "SC": {
+    "name": "Seychelles",
+    "native": "Seychelles",
+    "phone": [
+      248
+    ],
+    "continent": "AF",
+    "capital": "Victoria",
+    "currency": [
+      "SCR"
+    ],
+    "languages": [
+      "fr",
+      "en"
+    ]
+  },
+  "SD": {
+    "name": "Sudan",
+    "native": "السودان",
+    "phone": [
+      249
+    ],
+    "continent": "AF",
+    "capital": "Khartoum",
+    "currency": [
+      "SDG"
+    ],
+    "languages": [
+      "ar",
+      "en"
+    ]
+  },
+  "SE": {
+    "name": "Sweden",
+    "native": "Sverige",
+    "phone": [
+      46
+    ],
+    "continent": "EU",
+    "capital": "Stockholm",
+    "currency": [
+      "SEK"
+    ],
+    "languages": [
+      "sv"
+    ]
+  },
+  "SG": {
+    "name": "Singapore",
+    "native": "Singapore",
+    "phone": [
+      65
+    ],
+    "continent": "AS",
+    "capital": "Singapore",
+    "currency": [
+      "SGD"
+    ],
+    "languages": [
+      "en",
+      "ms",
+      "ta",
+      "zh"
+    ]
+  },
+  "SH": {
+    "name": "Saint Helena",
+    "native": "Saint Helena",
+    "phone": [
+      290
+    ],
+    "continent": "AF",
+    "capital": "Jamestown",
+    "currency": [
+      "SHP"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "SI": {
+    "name": "Slovenia",
+    "native": "Slovenija",
+    "phone": [
+      386
+    ],
+    "continent": "EU",
+    "capital": "Ljubljana",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "sl"
+    ]
+  },
+  "SJ": {
+    "name": "Svalbard and Jan Mayen",
+    "native": "Svalbard og Jan Mayen",
+    "phone": [
+      4779
+    ],
+    "continent": "EU",
+    "capital": "Longyearbyen",
+    "currency": [
+      "NOK"
+    ],
+    "languages": [
+      "no"
+    ]
+  },
+  "SK": {
+    "name": "Slovakia",
+    "native": "Slovensko",
+    "phone": [
+      421
+    ],
+    "continent": "EU",
+    "capital": "Bratislava",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "sk"
+    ]
+  },
+  "SL": {
+    "name": "Sierra Leone",
+    "native": "Sierra Leone",
+    "phone": [
+      232
+    ],
+    "continent": "AF",
+    "capital": "Freetown",
+    "currency": [
+      "SLL"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "SM": {
+    "name": "San Marino",
+    "native": "San Marino",
+    "phone": [
+      378
+    ],
+    "continent": "EU",
+    "capital": "City of San Marino",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "it"
+    ]
+  },
+  "SN": {
+    "name": "Senegal",
+    "native": "Sénégal",
+    "phone": [
+      221
+    ],
+    "continent": "AF",
+    "capital": "Dakar",
+    "currency": [
+      "XOF"
+    ],
+    "languages": [
+      "fr"
+    ]
+  },
+  "SO": {
+    "name": "Somalia",
+    "native": "Soomaaliya",
+    "phone": [
+      252
+    ],
+    "continent": "AF",
+    "capital": "Mogadishu",
+    "currency": [
+      "SOS"
+    ],
+    "languages": [
+      "so",
+      "ar"
+    ]
+  },
+  "SR": {
+    "name": "Suriname",
+    "native": "Suriname",
+    "phone": [
+      597
+    ],
+    "continent": "SA",
+    "capital": "Paramaribo",
+    "currency": [
+      "SRD"
+    ],
+    "languages": [
+      "nl"
+    ]
+  },
+  "SS": {
+    "name": "South Sudan",
+    "native": "South Sudan",
+    "phone": [
+      211
+    ],
+    "continent": "AF",
+    "capital": "Juba",
+    "currency": [
+      "SSP"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "ST": {
+    "name": "São Tomé and Príncipe",
+    "native": "São Tomé e Príncipe",
+    "phone": [
+      239
+    ],
+    "continent": "AF",
+    "capital": "São Tomé",
+    "currency": [
+      "STN"
+    ],
+    "languages": [
+      "pt"
+    ]
+  },
+  "SV": {
+    "name": "El Salvador",
+    "native": "El Salvador",
+    "phone": [
+      503
+    ],
+    "continent": "NA",
+    "capital": "San Salvador",
+    "currency": [
+      "SVC",
+      "USD"
+    ],
+    "languages": [
+      "es"
+    ]
+  },
+  "SX": {
+    "name": "Sint Maarten",
+    "native": "Sint Maarten",
+    "phone": [
+      1721
+    ],
+    "continent": "NA",
+    "capital": "Philipsburg",
+    "currency": [
+      "ANG"
+    ],
+    "languages": [
+      "nl",
+      "en"
+    ]
+  },
+  "SY": {
+    "name": "Syria",
+    "native": "سوريا",
+    "phone": [
+      963
+    ],
+    "continent": "AS",
+    "capital": "Damascus",
+    "currency": [
+      "SYP"
+    ],
+    "languages": [
+      "ar"
+    ]
+  },
+  "SZ": {
+    "name": "Swaziland",
+    "native": "Swaziland",
+    "phone": [
+      268
+    ],
+    "continent": "AF",
+    "capital": "Lobamba",
+    "currency": [
+      "SZL"
+    ],
+    "languages": [
+      "en",
+      "ss"
+    ]
+  },
+  "TC": {
+    "name": "Turks and Caicos Islands",
+    "native": "Turks and Caicos Islands",
+    "phone": [
+      1649
+    ],
+    "continent": "NA",
+    "capital": "Cockburn Town",
+    "currency": [
+      "USD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "TD": {
+    "name": "Chad",
+    "native": "Tchad",
+    "phone": [
+      235
+    ],
+    "continent": "AF",
+    "capital": "N'Djamena",
+    "currency": [
+      "XAF"
+    ],
+    "languages": [
+      "fr",
+      "ar"
+    ]
+  },
+  "TF": {
+    "name": "French Southern Territories",
+    "native": "Territoire des Terres australes et antarctiques fr",
+    "phone": [
+      262
+    ],
+    "continent": "AN",
+    "capital": "Port-aux-Français",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "fr"
+    ]
+  },
+  "TG": {
+    "name": "Togo",
+    "native": "Togo",
+    "phone": [
+      228
+    ],
+    "continent": "AF",
+    "capital": "Lomé",
+    "currency": [
+      "XOF"
+    ],
+    "languages": [
+      "fr"
+    ]
+  },
+  "TH": {
+    "name": "Thailand",
+    "native": "ประเทศไทย",
+    "phone": [
+      66
+    ],
+    "continent": "AS",
+    "capital": "Bangkok",
+    "currency": [
+      "THB"
+    ],
+    "languages": [
+      "th"
+    ]
+  },
+  "TJ": {
+    "name": "Tajikistan",
+    "native": "Тоҷикистон",
+    "phone": [
+      992
+    ],
+    "continent": "AS",
+    "capital": "Dushanbe",
+    "currency": [
+      "TJS"
+    ],
+    "languages": [
+      "tg",
+      "ru"
+    ]
+  },
+  "TK": {
+    "name": "Tokelau",
+    "native": "Tokelau",
+    "phone": [
+      690
+    ],
+    "continent": "OC",
+    "capital": "Fakaofo",
+    "currency": [
+      "NZD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "TL": {
+    "name": "East Timor",
+    "native": "Timor-Leste",
+    "phone": [
+      670
+    ],
+    "continent": "OC",
+    "capital": "Dili",
+    "currency": [
+      "USD"
+    ],
+    "languages": [
+      "pt"
+    ]
+  },
+  "TM": {
+    "name": "Turkmenistan",
+    "native": "Türkmenistan",
+    "phone": [
+      993
+    ],
+    "continent": "AS",
+    "capital": "Ashgabat",
+    "currency": [
+      "TMT"
+    ],
+    "languages": [
+      "tk",
+      "ru"
+    ]
+  },
+  "TN": {
+    "name": "Tunisia",
+    "native": "تونس",
+    "phone": [
+      216
+    ],
+    "continent": "AF",
+    "capital": "Tunis",
+    "currency": [
+      "TND"
+    ],
+    "languages": [
+      "ar"
+    ]
+  },
+  "TO": {
+    "name": "Tonga",
+    "native": "Tonga",
+    "phone": [
+      676
+    ],
+    "continent": "OC",
+    "capital": "Nuku'alofa",
+    "currency": [
+      "TOP"
+    ],
+    "languages": [
+      "en",
+      "to"
+    ]
+  },
+  "TR": {
+    "name": "Turkey",
+    "native": "Türkiye",
+    "phone": [
+      90
+    ],
+    "continent": "AS",
+    "continents": [
+      "AS",
+      "EU"
+    ],
+    "capital": "Ankara",
+    "currency": [
+      "TRY"
+    ],
+    "languages": [
+      "tr"
+    ]
+  },
+  "TT": {
+    "name": "Trinidad and Tobago",
+    "native": "Trinidad and Tobago",
+    "phone": [
+      1868
+    ],
+    "continent": "NA",
+    "capital": "Port of Spain",
+    "currency": [
+      "TTD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "TV": {
+    "name": "Tuvalu",
+    "native": "Tuvalu",
+    "phone": [
+      688
+    ],
+    "continent": "OC",
+    "capital": "Funafuti",
+    "currency": [
+      "AUD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "TW": {
+    "name": "Taiwan",
+    "native": "臺灣",
+    "phone": [
+      886
+    ],
+    "continent": "AS",
+    "capital": "Taipei",
+    "currency": [
+      "TWD"
+    ],
+    "languages": [
+      "zh"
+    ]
+  },
+  "TZ": {
+    "name": "Tanzania",
+    "native": "Tanzania",
+    "phone": [
+      255
+    ],
+    "continent": "AF",
+    "capital": "Dodoma",
+    "currency": [
+      "TZS"
+    ],
+    "languages": [
+      "sw",
+      "en"
+    ]
+  },
+  "UA": {
+    "name": "Ukraine",
+    "native": "Україна",
+    "phone": [
+      380
+    ],
+    "continent": "EU",
+    "capital": "Kyiv",
+    "currency": [
+      "UAH"
+    ],
+    "languages": [
+      "uk"
+    ]
+  },
+  "UG": {
+    "name": "Uganda",
+    "native": "Uganda",
+    "phone": [
+      256
+    ],
+    "continent": "AF",
+    "capital": "Kampala",
+    "currency": [
+      "UGX"
+    ],
+    "languages": [
+      "en",
+      "sw"
+    ]
+  },
+  "UM": {
+    "name": "U.S. Minor Outlying Islands",
+    "native": "United States Minor Outlying Islands",
+    "phone": [
+      1
+    ],
+    "continent": "OC",
+    "capital": "",
+    "currency": [
+      "USD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "US": {
+    "name": "United States",
+    "native": "United States",
+    "phone": [
+      1
+    ],
+    "continent": "NA",
+    "capital": "Washington D.C.",
+    "currency": [
+      "USD",
+      "USN",
+      "USS"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "UY": {
+    "name": "Uruguay",
+    "native": "Uruguay",
+    "phone": [
+      598
+    ],
+    "continent": "SA",
+    "capital": "Montevideo",
+    "currency": [
+      "UYI",
+      "UYU"
+    ],
+    "languages": [
+      "es"
+    ]
+  },
+  "UZ": {
+    "name": "Uzbekistan",
+    "native": "O‘zbekiston",
+    "phone": [
+      998
+    ],
+    "continent": "AS",
+    "capital": "Tashkent",
+    "currency": [
+      "UZS"
+    ],
+    "languages": [
+      "uz",
+      "ru"
+    ]
+  },
+  "VA": {
+    "name": "Vatican City",
+    "native": "Vaticano",
+    "phone": [
+      379
+    ],
+    "continent": "EU",
+    "capital": "Vatican City",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "it",
+      "la"
+    ]
+  },
+  "VC": {
+    "name": "Saint Vincent and the Grenadines",
+    "native": "Saint Vincent and the Grenadines",
+    "phone": [
+      1784
+    ],
+    "continent": "NA",
+    "capital": "Kingstown",
+    "currency": [
+      "XCD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "VE": {
+    "name": "Venezuela",
+    "native": "Venezuela",
+    "phone": [
+      58
+    ],
+    "continent": "SA",
+    "capital": "Caracas",
+    "currency": [
+      "VES"
+    ],
+    "languages": [
+      "es"
+    ]
+  },
+  "VG": {
+    "name": "British Virgin Islands",
+    "native": "British Virgin Islands",
+    "phone": [
+      1284
+    ],
+    "continent": "NA",
+    "capital": "Road Town",
+    "currency": [
+      "USD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "VI": {
+    "name": "U.S. Virgin Islands",
+    "native": "United States Virgin Islands",
+    "phone": [
+      1340
+    ],
+    "continent": "NA",
+    "capital": "Charlotte Amalie",
+    "currency": [
+      "USD"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "VN": {
+    "name": "Vietnam",
+    "native": "Việt Nam",
+    "phone": [
+      84
+    ],
+    "continent": "AS",
+    "capital": "Hanoi",
+    "currency": [
+      "VND"
+    ],
+    "languages": [
+      "vi"
+    ]
+  },
+  "VU": {
+    "name": "Vanuatu",
+    "native": "Vanuatu",
+    "phone": [
+      678
+    ],
+    "continent": "OC",
+    "capital": "Port Vila",
+    "currency": [
+      "VUV"
+    ],
+    "languages": [
+      "bi",
+      "en",
+      "fr"
+    ]
+  },
+  "WF": {
+    "name": "Wallis and Futuna",
+    "native": "Wallis et Futuna",
+    "phone": [
+      681
+    ],
+    "continent": "OC",
+    "capital": "Mata-Utu",
+    "currency": [
+      "XPF"
+    ],
+    "languages": [
+      "fr"
+    ]
+  },
+  "WS": {
+    "name": "Samoa",
+    "native": "Samoa",
+    "phone": [
+      685
+    ],
+    "continent": "OC",
+    "capital": "Apia",
+    "currency": [
+      "WST"
+    ],
+    "languages": [
+      "sm",
+      "en"
+    ]
+  },
+  "XK": {
+    "name": "Kosovo",
+    "native": "Republika e Kosovës",
+    "phone": [
+      377,
+      381,
+      383,
+      386
+    ],
+    "continent": "EU",
+    "capital": "Pristina",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "sq",
+      "sr"
+    ]
+  },
+  "YE": {
+    "name": "Yemen",
+    "native": "اليَمَن",
+    "phone": [
+      967
+    ],
+    "continent": "AS",
+    "capital": "Sana'a",
+    "currency": [
+      "YER"
+    ],
+    "languages": [
+      "ar"
+    ]
+  },
+  "YT": {
+    "name": "Mayotte",
+    "native": "Mayotte",
+    "phone": [
+      262
+    ],
+    "continent": "AF",
+    "capital": "Mamoudzou",
+    "currency": [
+      "EUR"
+    ],
+    "languages": [
+      "fr"
+    ]
+  },
+  "ZA": {
+    "name": "South Africa",
+    "native": "South Africa",
+    "phone": [
+      27
+    ],
+    "continent": "AF",
+    "capital": "Pretoria",
+    "currency": [
+      "ZAR"
+    ],
+    "languages": [
+      "af",
+      "en",
+      "nr",
+      "st",
+      "ss",
+      "tn",
+      "ts",
+      "ve",
+      "xh",
+      "zu"
+    ]
+  },
+  "ZM": {
+    "name": "Zambia",
+    "native": "Zambia",
+    "phone": [
+      260
+    ],
+    "continent": "AF",
+    "capital": "Lusaka",
+    "currency": [
+      "ZMW"
+    ],
+    "languages": [
+      "en"
+    ]
+  },
+  "ZW": {
+    "name": "Zimbabwe",
+    "native": "Zimbabwe",
+    "phone": [
+      263
+    ],
+    "continent": "AF",
+    "capital": "Harare",
+    "currency": [
+      "USD",
+      "ZAR",
+      "BWP",
+      "GBP",
+      "AUD",
+      "CNY",
+      "INR",
+      "JPY"
+    ],
+    "languages": [
+      "en",
+      "sn",
+      "nd"
+    ]
+  }
+}

--- a/examples/context_sensitive_completion/data/data.json
+++ b/examples/context_sensitive_completion/data/data.json
@@ -1,0 +1,5406 @@
+{
+   "_description" : {
+      "generated_by" : "munge_country_data.pl",
+      "sources" : {
+         "_repository" : "https://github.com/annexare/Countries",
+         "continents.json" : "master/data/continents.json",
+         "countries.json" : "master/data/countries.json"
+      }
+   },
+   "cities" : {
+      "Abu Dhabi" : {
+         "countries" : [
+            "United Arab Emirates"
+         ],
+         "name" : "Abu Dhabi"
+      },
+      "Abuja" : {
+         "countries" : [
+            "Nigeria"
+         ],
+         "name" : "Abuja"
+      },
+      "Accra" : {
+         "countries" : [
+            "Ghana"
+         ],
+         "name" : "Accra"
+      },
+      "Adamstown" : {
+         "countries" : [
+            "Pitcairn Islands"
+         ],
+         "name" : "Adamstown"
+      },
+      "Addis Ababa" : {
+         "countries" : [
+            "Ethiopia"
+         ],
+         "name" : "Addis Ababa"
+      },
+      "Algiers" : {
+         "countries" : [
+            "Algeria"
+         ],
+         "name" : "Algiers"
+      },
+      "Alofi" : {
+         "countries" : [
+            "Niue"
+         ],
+         "name" : "Alofi"
+      },
+      "Amman" : {
+         "countries" : [
+            "Jordan"
+         ],
+         "name" : "Amman"
+      },
+      "Amsterdam" : {
+         "countries" : [
+            "Netherlands"
+         ],
+         "name" : "Amsterdam"
+      },
+      "Andorra la Vella" : {
+         "countries" : [
+            "Andorra"
+         ],
+         "name" : "Andorra la Vella"
+      },
+      "Ankara" : {
+         "countries" : [
+            "Turkey"
+         ],
+         "name" : "Ankara"
+      },
+      "Antananarivo" : {
+         "countries" : [
+            "Madagascar"
+         ],
+         "name" : "Antananarivo"
+      },
+      "Antarctica" : {
+         "countries" : [
+            "Antarctica"
+         ],
+         "name" : "Antarctica"
+      },
+      "Apia" : {
+         "countries" : [
+            "Samoa"
+         ],
+         "name" : "Apia"
+      },
+      "Ashgabat" : {
+         "countries" : [
+            "Turkmenistan"
+         ],
+         "name" : "Ashgabat"
+      },
+      "Asmara" : {
+         "countries" : [
+            "Eritrea"
+         ],
+         "name" : "Asmara"
+      },
+      "Astana" : {
+         "countries" : [
+            "Kazakhstan"
+         ],
+         "name" : "Astana"
+      },
+      "Asunción" : {
+         "countries" : [
+            "Paraguay"
+         ],
+         "name" : "Asunción"
+      },
+      "Athens" : {
+         "countries" : [
+            "Greece"
+         ],
+         "name" : "Athens"
+      },
+      "Avarua" : {
+         "countries" : [
+            "Cook Islands"
+         ],
+         "name" : "Avarua"
+      },
+      "Baghdad" : {
+         "countries" : [
+            "Iraq"
+         ],
+         "name" : "Baghdad"
+      },
+      "Baku" : {
+         "countries" : [
+            "Azerbaijan"
+         ],
+         "name" : "Baku"
+      },
+      "Bamako" : {
+         "countries" : [
+            "Mali"
+         ],
+         "name" : "Bamako"
+      },
+      "Bandar Seri Begawan" : {
+         "countries" : [
+            "Brunei"
+         ],
+         "name" : "Bandar Seri Begawan"
+      },
+      "Bangkok" : {
+         "countries" : [
+            "Thailand"
+         ],
+         "name" : "Bangkok"
+      },
+      "Bangui" : {
+         "countries" : [
+            "Central African Republic"
+         ],
+         "name" : "Bangui"
+      },
+      "Banjul" : {
+         "countries" : [
+            "Gambia"
+         ],
+         "name" : "Banjul"
+      },
+      "Basse-Terre" : {
+         "countries" : [
+            "Guadeloupe"
+         ],
+         "name" : "Basse-Terre"
+      },
+      "Basseterre" : {
+         "countries" : [
+            "Saint Kitts and Nevis"
+         ],
+         "name" : "Basseterre"
+      },
+      "Beijing" : {
+         "countries" : [
+            "China"
+         ],
+         "name" : "Beijing"
+      },
+      "Beirut" : {
+         "countries" : [
+            "Lebanon"
+         ],
+         "name" : "Beirut"
+      },
+      "Belgrade" : {
+         "countries" : [
+            "Serbia"
+         ],
+         "name" : "Belgrade"
+      },
+      "Belmopan" : {
+         "countries" : [
+            "Belize"
+         ],
+         "name" : "Belmopan"
+      },
+      "Berlin" : {
+         "countries" : [
+            "Germany"
+         ],
+         "name" : "Berlin"
+      },
+      "Bern" : {
+         "countries" : [
+            "Switzerland"
+         ],
+         "name" : "Bern"
+      },
+      "Bishkek" : {
+         "countries" : [
+            "Kyrgyzstan"
+         ],
+         "name" : "Bishkek"
+      },
+      "Bissau" : {
+         "countries" : [
+            "Guinea-Bissau"
+         ],
+         "name" : "Bissau"
+      },
+      "Bogotá" : {
+         "countries" : [
+            "Colombia"
+         ],
+         "name" : "Bogotá"
+      },
+      "Bouvet Island" : {
+         "countries" : [
+            "Bouvet Island"
+         ],
+         "name" : "Bouvet Island"
+      },
+      "Brasília" : {
+         "countries" : [
+            "Brazil"
+         ],
+         "name" : "Brasília"
+      },
+      "Bratislava" : {
+         "countries" : [
+            "Slovakia"
+         ],
+         "name" : "Bratislava"
+      },
+      "Brazzaville" : {
+         "countries" : [
+            "Republic of the Congo"
+         ],
+         "name" : "Brazzaville"
+      },
+      "Bridgetown" : {
+         "countries" : [
+            "Barbados"
+         ],
+         "name" : "Bridgetown"
+      },
+      "Brussels" : {
+         "countries" : [
+            "Belgium"
+         ],
+         "name" : "Brussels"
+      },
+      "Bucharest" : {
+         "countries" : [
+            "Romania"
+         ],
+         "name" : "Bucharest"
+      },
+      "Budapest" : {
+         "countries" : [
+            "Hungary"
+         ],
+         "name" : "Budapest"
+      },
+      "Buenos Aires" : {
+         "countries" : [
+            "Argentina"
+         ],
+         "name" : "Buenos Aires"
+      },
+      "Bujumbura" : {
+         "countries" : [
+            "Burundi"
+         ],
+         "name" : "Bujumbura"
+      },
+      "Cairo" : {
+         "countries" : [
+            "Egypt"
+         ],
+         "name" : "Cairo"
+      },
+      "Canberra" : {
+         "countries" : [
+            "Australia"
+         ],
+         "name" : "Canberra"
+      },
+      "Caracas" : {
+         "countries" : [
+            "Venezuela"
+         ],
+         "name" : "Caracas"
+      },
+      "Castries" : {
+         "countries" : [
+            "Saint Lucia"
+         ],
+         "name" : "Castries"
+      },
+      "Cayenne" : {
+         "countries" : [
+            "French Guiana"
+         ],
+         "name" : "Cayenne"
+      },
+      "Charlotte Amalie" : {
+         "countries" : [
+            "U.S. Virgin Islands"
+         ],
+         "name" : "Charlotte Amalie"
+      },
+      "Chișinău" : {
+         "countries" : [
+            "Moldova"
+         ],
+         "name" : "Chișinău"
+      },
+      "City of San Marino" : {
+         "countries" : [
+            "San Marino"
+         ],
+         "name" : "City of San Marino"
+      },
+      "City of Victoria" : {
+         "countries" : [
+            "Hong Kong"
+         ],
+         "name" : "City of Victoria"
+      },
+      "Cockburn Town" : {
+         "countries" : [
+            "Turks and Caicos Islands"
+         ],
+         "name" : "Cockburn Town"
+      },
+      "Colombo" : {
+         "countries" : [
+            "Sri Lanka"
+         ],
+         "name" : "Colombo"
+      },
+      "Conakry" : {
+         "countries" : [
+            "Guinea"
+         ],
+         "name" : "Conakry"
+      },
+      "Copenhagen" : {
+         "countries" : [
+            "Denmark"
+         ],
+         "name" : "Copenhagen"
+      },
+      "Dakar" : {
+         "countries" : [
+            "Senegal"
+         ],
+         "name" : "Dakar"
+      },
+      "Damascus" : {
+         "countries" : [
+            "Syria"
+         ],
+         "name" : "Damascus"
+      },
+      "Dhaka" : {
+         "countries" : [
+            "Bangladesh"
+         ],
+         "name" : "Dhaka"
+      },
+      "Diego Garcia" : {
+         "countries" : [
+            "British Indian Ocean Territory"
+         ],
+         "name" : "Diego Garcia"
+      },
+      "Dili" : {
+         "countries" : [
+            "East Timor"
+         ],
+         "name" : "Dili"
+      },
+      "Djibouti" : {
+         "countries" : [
+            "Djibouti"
+         ],
+         "name" : "Djibouti"
+      },
+      "Dodoma" : {
+         "countries" : [
+            "Tanzania"
+         ],
+         "name" : "Dodoma"
+      },
+      "Doha" : {
+         "countries" : [
+            "Qatar"
+         ],
+         "name" : "Doha"
+      },
+      "Douglas" : {
+         "countries" : [
+            "Isle of Man"
+         ],
+         "name" : "Douglas"
+      },
+      "Dublin" : {
+         "countries" : [
+            "Ireland"
+         ],
+         "name" : "Dublin"
+      },
+      "Dushanbe" : {
+         "countries" : [
+            "Tajikistan"
+         ],
+         "name" : "Dushanbe"
+      },
+      "El Aaiún" : {
+         "countries" : [
+            "Western Sahara"
+         ],
+         "name" : "El Aaiún"
+      },
+      "Fakaofo" : {
+         "countries" : [
+            "Tokelau"
+         ],
+         "name" : "Fakaofo"
+      },
+      "Flying Fish Cove" : {
+         "countries" : [
+            "Christmas Island"
+         ],
+         "name" : "Flying Fish Cove"
+      },
+      "Fort-de-France" : {
+         "countries" : [
+            "Martinique"
+         ],
+         "name" : "Fort-de-France"
+      },
+      "Freetown" : {
+         "countries" : [
+            "Sierra Leone"
+         ],
+         "name" : "Freetown"
+      },
+      "Funafuti" : {
+         "countries" : [
+            "Tuvalu"
+         ],
+         "name" : "Funafuti"
+      },
+      "Gaborone" : {
+         "countries" : [
+            "Botswana"
+         ],
+         "name" : "Gaborone"
+      },
+      "George Town" : {
+         "countries" : [
+            "Cayman Islands"
+         ],
+         "name" : "George Town"
+      },
+      "Georgetown" : {
+         "countries" : [
+            "Guyana"
+         ],
+         "name" : "Georgetown"
+      },
+      "Gibraltar" : {
+         "countries" : [
+            "Gibraltar"
+         ],
+         "name" : "Gibraltar"
+      },
+      "Guatemala City" : {
+         "countries" : [
+            "Guatemala"
+         ],
+         "name" : "Guatemala City"
+      },
+      "Gustavia" : {
+         "countries" : [
+            "Saint Barthélemy"
+         ],
+         "name" : "Gustavia"
+      },
+      "Hagåtña" : {
+         "countries" : [
+            "Guam"
+         ],
+         "name" : "Hagåtña"
+      },
+      "Hamilton" : {
+         "countries" : [
+            "Bermuda"
+         ],
+         "name" : "Hamilton"
+      },
+      "Hanoi" : {
+         "countries" : [
+            "Vietnam"
+         ],
+         "name" : "Hanoi"
+      },
+      "Harare" : {
+         "countries" : [
+            "Zimbabwe"
+         ],
+         "name" : "Harare"
+      },
+      "Havana" : {
+         "countries" : [
+            "Cuba"
+         ],
+         "name" : "Havana"
+      },
+      "Heard Island and McDonald Islands" : {
+         "countries" : [
+            "Heard Island and McDonald Islands"
+         ],
+         "name" : "Heard Island and McDonald Islands"
+      },
+      "Helsinki" : {
+         "countries" : [
+            "Finland"
+         ],
+         "name" : "Helsinki"
+      },
+      "Honiara" : {
+         "countries" : [
+            "Solomon Islands"
+         ],
+         "name" : "Honiara"
+      },
+      "Islamabad" : {
+         "countries" : [
+            "Pakistan"
+         ],
+         "name" : "Islamabad"
+      },
+      "Jakarta" : {
+         "countries" : [
+            "Indonesia"
+         ],
+         "name" : "Jakarta"
+      },
+      "Jamestown" : {
+         "countries" : [
+            "Saint Helena"
+         ],
+         "name" : "Jamestown"
+      },
+      "Jerusalem" : {
+         "countries" : [
+            "Israel"
+         ],
+         "name" : "Jerusalem"
+      },
+      "Juba" : {
+         "countries" : [
+            "South Sudan"
+         ],
+         "name" : "Juba"
+      },
+      "Kabul" : {
+         "countries" : [
+            "Afghanistan"
+         ],
+         "name" : "Kabul"
+      },
+      "Kampala" : {
+         "countries" : [
+            "Uganda"
+         ],
+         "name" : "Kampala"
+      },
+      "Kathmandu" : {
+         "countries" : [
+            "Nepal"
+         ],
+         "name" : "Kathmandu"
+      },
+      "Khartoum" : {
+         "countries" : [
+            "Sudan"
+         ],
+         "name" : "Khartoum"
+      },
+      "Kigali" : {
+         "countries" : [
+            "Rwanda"
+         ],
+         "name" : "Kigali"
+      },
+      "King Edward Point" : {
+         "countries" : [
+            "South Georgia and the South Sandwich Islands"
+         ],
+         "name" : "King Edward Point"
+      },
+      "Kingston" : {
+         "countries" : [
+            "Norfolk Island",
+            "Jamaica"
+         ],
+         "name" : "Kingston"
+      },
+      "Kingstown" : {
+         "countries" : [
+            "Saint Vincent and the Grenadines"
+         ],
+         "name" : "Kingstown"
+      },
+      "Kinshasa" : {
+         "countries" : [
+            "Democratic Republic of the Congo"
+         ],
+         "name" : "Kinshasa"
+      },
+      "Kralendijk" : {
+         "countries" : [
+            "Bonaire"
+         ],
+         "name" : "Kralendijk"
+      },
+      "Kuala Lumpur" : {
+         "countries" : [
+            "Malaysia"
+         ],
+         "name" : "Kuala Lumpur"
+      },
+      "Kuwait City" : {
+         "countries" : [
+            "Kuwait"
+         ],
+         "name" : "Kuwait City"
+      },
+      "Kyiv" : {
+         "countries" : [
+            "Ukraine"
+         ],
+         "name" : "Kyiv"
+      },
+      "Libreville" : {
+         "countries" : [
+            "Gabon"
+         ],
+         "name" : "Libreville"
+      },
+      "Lilongwe" : {
+         "countries" : [
+            "Malawi"
+         ],
+         "name" : "Lilongwe"
+      },
+      "Lima" : {
+         "countries" : [
+            "Peru"
+         ],
+         "name" : "Lima"
+      },
+      "Lisbon" : {
+         "countries" : [
+            "Portugal"
+         ],
+         "name" : "Lisbon"
+      },
+      "Ljubljana" : {
+         "countries" : [
+            "Slovenia"
+         ],
+         "name" : "Ljubljana"
+      },
+      "Lobamba" : {
+         "countries" : [
+            "Swaziland"
+         ],
+         "name" : "Lobamba"
+      },
+      "Lomé" : {
+         "countries" : [
+            "Togo"
+         ],
+         "name" : "Lomé"
+      },
+      "London" : {
+         "countries" : [
+            "United Kingdom"
+         ],
+         "name" : "London"
+      },
+      "Longyearbyen" : {
+         "countries" : [
+            "Svalbard and Jan Mayen"
+         ],
+         "name" : "Longyearbyen"
+      },
+      "Luanda" : {
+         "countries" : [
+            "Angola"
+         ],
+         "name" : "Luanda"
+      },
+      "Lusaka" : {
+         "countries" : [
+            "Zambia"
+         ],
+         "name" : "Lusaka"
+      },
+      "Luxembourg" : {
+         "countries" : [
+            "Luxembourg"
+         ],
+         "name" : "Luxembourg"
+      },
+      "Macao" : {
+         "countries" : [
+            "Macao"
+         ],
+         "name" : "Macao"
+      },
+      "Madrid" : {
+         "countries" : [
+            "Spain"
+         ],
+         "name" : "Madrid"
+      },
+      "Majuro" : {
+         "countries" : [
+            "Marshall Islands"
+         ],
+         "name" : "Majuro"
+      },
+      "Malabo" : {
+         "countries" : [
+            "Equatorial Guinea"
+         ],
+         "name" : "Malabo"
+      },
+      "Malé" : {
+         "countries" : [
+            "Maldives"
+         ],
+         "name" : "Malé"
+      },
+      "Mamoudzou" : {
+         "countries" : [
+            "Mayotte"
+         ],
+         "name" : "Mamoudzou"
+      },
+      "Managua" : {
+         "countries" : [
+            "Nicaragua"
+         ],
+         "name" : "Managua"
+      },
+      "Manama" : {
+         "countries" : [
+            "Bahrain"
+         ],
+         "name" : "Manama"
+      },
+      "Manila" : {
+         "countries" : [
+            "Philippines"
+         ],
+         "name" : "Manila"
+      },
+      "Maputo" : {
+         "countries" : [
+            "Mozambique"
+         ],
+         "name" : "Maputo"
+      },
+      "Mariehamn" : {
+         "countries" : [
+            "Åland"
+         ],
+         "name" : "Mariehamn"
+      },
+      "Marigot" : {
+         "countries" : [
+            "Saint Martin"
+         ],
+         "name" : "Marigot"
+      },
+      "Maseru" : {
+         "countries" : [
+            "Lesotho"
+         ],
+         "name" : "Maseru"
+      },
+      "Mata-Utu" : {
+         "countries" : [
+            "Wallis and Futuna"
+         ],
+         "name" : "Mata-Utu"
+      },
+      "Mexico City" : {
+         "countries" : [
+            "Mexico"
+         ],
+         "name" : "Mexico City"
+      },
+      "Minsk" : {
+         "countries" : [
+            "Belarus"
+         ],
+         "name" : "Minsk"
+      },
+      "Mogadishu" : {
+         "countries" : [
+            "Somalia"
+         ],
+         "name" : "Mogadishu"
+      },
+      "Monaco" : {
+         "countries" : [
+            "Monaco"
+         ],
+         "name" : "Monaco"
+      },
+      "Monrovia" : {
+         "countries" : [
+            "Liberia"
+         ],
+         "name" : "Monrovia"
+      },
+      "Montevideo" : {
+         "countries" : [
+            "Uruguay"
+         ],
+         "name" : "Montevideo"
+      },
+      "Moroni" : {
+         "countries" : [
+            "Comoros"
+         ],
+         "name" : "Moroni"
+      },
+      "Moscow" : {
+         "countries" : [
+            "Russia"
+         ],
+         "name" : "Moscow"
+      },
+      "Muscat" : {
+         "countries" : [
+            "Oman"
+         ],
+         "name" : "Muscat"
+      },
+      "N'Djamena" : {
+         "countries" : [
+            "Chad"
+         ],
+         "name" : "N'Djamena"
+      },
+      "Nairobi" : {
+         "countries" : [
+            "Kenya"
+         ],
+         "name" : "Nairobi"
+      },
+      "Nassau" : {
+         "countries" : [
+            "Bahamas"
+         ],
+         "name" : "Nassau"
+      },
+      "Naypyidaw" : {
+         "countries" : [
+            "Myanmar [Burma]"
+         ],
+         "name" : "Naypyidaw"
+      },
+      "New Delhi" : {
+         "countries" : [
+            "India"
+         ],
+         "name" : "New Delhi"
+      },
+      "Ngerulmud" : {
+         "countries" : [
+            "Palau"
+         ],
+         "name" : "Ngerulmud"
+      },
+      "Niamey" : {
+         "countries" : [
+            "Niger"
+         ],
+         "name" : "Niamey"
+      },
+      "Nicosia" : {
+         "countries" : [
+            "Cyprus"
+         ],
+         "name" : "Nicosia"
+      },
+      "Nouakchott" : {
+         "countries" : [
+            "Mauritania"
+         ],
+         "name" : "Nouakchott"
+      },
+      "Nouméa" : {
+         "countries" : [
+            "New Caledonia"
+         ],
+         "name" : "Nouméa"
+      },
+      "Nuku'alofa" : {
+         "countries" : [
+            "Tonga"
+         ],
+         "name" : "Nuku'alofa"
+      },
+      "Nuuk" : {
+         "countries" : [
+            "Greenland"
+         ],
+         "name" : "Nuuk"
+      },
+      "Oranjestad" : {
+         "countries" : [
+            "Aruba"
+         ],
+         "name" : "Oranjestad"
+      },
+      "Oslo" : {
+         "countries" : [
+            "Norway"
+         ],
+         "name" : "Oslo"
+      },
+      "Ottawa" : {
+         "countries" : [
+            "Canada"
+         ],
+         "name" : "Ottawa"
+      },
+      "Ouagadougou" : {
+         "countries" : [
+            "Burkina Faso"
+         ],
+         "name" : "Ouagadougou"
+      },
+      "Pago Pago" : {
+         "countries" : [
+            "American Samoa"
+         ],
+         "name" : "Pago Pago"
+      },
+      "Palikir" : {
+         "countries" : [
+            "Micronesia"
+         ],
+         "name" : "Palikir"
+      },
+      "Panama City" : {
+         "countries" : [
+            "Panama"
+         ],
+         "name" : "Panama City"
+      },
+      "Papeetē" : {
+         "countries" : [
+            "French Polynesia"
+         ],
+         "name" : "Papeetē"
+      },
+      "Paramaribo" : {
+         "countries" : [
+            "Suriname"
+         ],
+         "name" : "Paramaribo"
+      },
+      "Paris" : {
+         "countries" : [
+            "France"
+         ],
+         "name" : "Paris"
+      },
+      "Philipsburg" : {
+         "countries" : [
+            "Sint Maarten"
+         ],
+         "name" : "Philipsburg"
+      },
+      "Phnom Penh" : {
+         "countries" : [
+            "Cambodia"
+         ],
+         "name" : "Phnom Penh"
+      },
+      "Plymouth" : {
+         "countries" : [
+            "Montserrat"
+         ],
+         "name" : "Plymouth"
+      },
+      "Podgorica" : {
+         "countries" : [
+            "Montenegro"
+         ],
+         "name" : "Podgorica"
+      },
+      "Port Louis" : {
+         "countries" : [
+            "Mauritius"
+         ],
+         "name" : "Port Louis"
+      },
+      "Port Moresby" : {
+         "countries" : [
+            "Papua New Guinea"
+         ],
+         "name" : "Port Moresby"
+      },
+      "Port Vila" : {
+         "countries" : [
+            "Vanuatu"
+         ],
+         "name" : "Port Vila"
+      },
+      "Port of Spain" : {
+         "countries" : [
+            "Trinidad and Tobago"
+         ],
+         "name" : "Port of Spain"
+      },
+      "Port-au-Prince" : {
+         "countries" : [
+            "Haiti"
+         ],
+         "name" : "Port-au-Prince"
+      },
+      "Port-aux-Français" : {
+         "countries" : [
+            "French Southern Territories"
+         ],
+         "name" : "Port-aux-Français"
+      },
+      "Porto-Novo" : {
+         "countries" : [
+            "Benin"
+         ],
+         "name" : "Porto-Novo"
+      },
+      "Prague" : {
+         "countries" : [
+            "Czech Republic"
+         ],
+         "name" : "Prague"
+      },
+      "Praia" : {
+         "countries" : [
+            "Cape Verde"
+         ],
+         "name" : "Praia"
+      },
+      "Pretoria" : {
+         "countries" : [
+            "South Africa"
+         ],
+         "name" : "Pretoria"
+      },
+      "Pristina" : {
+         "countries" : [
+            "Kosovo"
+         ],
+         "name" : "Pristina"
+      },
+      "Pyongyang" : {
+         "countries" : [
+            "North Korea"
+         ],
+         "name" : "Pyongyang"
+      },
+      "Quito" : {
+         "countries" : [
+            "Ecuador"
+         ],
+         "name" : "Quito"
+      },
+      "Rabat" : {
+         "countries" : [
+            "Morocco"
+         ],
+         "name" : "Rabat"
+      },
+      "Ramallah" : {
+         "countries" : [
+            "Palestine"
+         ],
+         "name" : "Ramallah"
+      },
+      "Reykjavik" : {
+         "countries" : [
+            "Iceland"
+         ],
+         "name" : "Reykjavik"
+      },
+      "Riga" : {
+         "countries" : [
+            "Latvia"
+         ],
+         "name" : "Riga"
+      },
+      "Riyadh" : {
+         "countries" : [
+            "Saudi Arabia"
+         ],
+         "name" : "Riyadh"
+      },
+      "Road Town" : {
+         "countries" : [
+            "British Virgin Islands"
+         ],
+         "name" : "Road Town"
+      },
+      "Rome" : {
+         "countries" : [
+            "Italy"
+         ],
+         "name" : "Rome"
+      },
+      "Roseau" : {
+         "countries" : [
+            "Dominica"
+         ],
+         "name" : "Roseau"
+      },
+      "Saint Helier" : {
+         "countries" : [
+            "Jersey"
+         ],
+         "name" : "Saint Helier"
+      },
+      "Saint John's" : {
+         "countries" : [
+            "Antigua and Barbuda"
+         ],
+         "name" : "Saint John's"
+      },
+      "Saint-Denis" : {
+         "countries" : [
+            "Réunion"
+         ],
+         "name" : "Saint-Denis"
+      },
+      "Saint-Pierre" : {
+         "countries" : [
+            "Saint Pierre and Miquelon"
+         ],
+         "name" : "Saint-Pierre"
+      },
+      "Saipan" : {
+         "countries" : [
+            "Northern Mariana Islands"
+         ],
+         "name" : "Saipan"
+      },
+      "San José" : {
+         "countries" : [
+            "Costa Rica"
+         ],
+         "name" : "San José"
+      },
+      "San Juan" : {
+         "countries" : [
+            "Puerto Rico"
+         ],
+         "name" : "San Juan"
+      },
+      "San Salvador" : {
+         "countries" : [
+            "El Salvador"
+         ],
+         "name" : "San Salvador"
+      },
+      "Sana'a" : {
+         "countries" : [
+            "Yemen"
+         ],
+         "name" : "Sana'a"
+      },
+      "Santiago" : {
+         "countries" : [
+            "Chile"
+         ],
+         "name" : "Santiago"
+      },
+      "Santo Domingo" : {
+         "countries" : [
+            "Dominican Republic"
+         ],
+         "name" : "Santo Domingo"
+      },
+      "Sarajevo" : {
+         "countries" : [
+            "Bosnia and Herzegovina"
+         ],
+         "name" : "Sarajevo"
+      },
+      "Seoul" : {
+         "countries" : [
+            "South Korea"
+         ],
+         "name" : "Seoul"
+      },
+      "Singapore" : {
+         "countries" : [
+            "Singapore"
+         ],
+         "name" : "Singapore"
+      },
+      "Skopje" : {
+         "countries" : [
+            "North Macedonia"
+         ],
+         "name" : "Skopje"
+      },
+      "Sofia" : {
+         "countries" : [
+            "Bulgaria"
+         ],
+         "name" : "Sofia"
+      },
+      "South Tarawa" : {
+         "countries" : [
+            "Kiribati"
+         ],
+         "name" : "South Tarawa"
+      },
+      "St. George's" : {
+         "countries" : [
+            "Grenada"
+         ],
+         "name" : "St. George's"
+      },
+      "St. Peter Port" : {
+         "countries" : [
+            "Guernsey"
+         ],
+         "name" : "St. Peter Port"
+      },
+      "Stanley" : {
+         "countries" : [
+            "Falkland Islands"
+         ],
+         "name" : "Stanley"
+      },
+      "Stockholm" : {
+         "countries" : [
+            "Sweden"
+         ],
+         "name" : "Stockholm"
+      },
+      "Sucre" : {
+         "countries" : [
+            "Bolivia"
+         ],
+         "name" : "Sucre"
+      },
+      "Suva" : {
+         "countries" : [
+            "Fiji"
+         ],
+         "name" : "Suva"
+      },
+      "São Tomé" : {
+         "countries" : [
+            "São Tomé and Príncipe"
+         ],
+         "name" : "São Tomé"
+      },
+      "Taipei" : {
+         "countries" : [
+            "Taiwan"
+         ],
+         "name" : "Taipei"
+      },
+      "Tallinn" : {
+         "countries" : [
+            "Estonia"
+         ],
+         "name" : "Tallinn"
+      },
+      "Tashkent" : {
+         "countries" : [
+            "Uzbekistan"
+         ],
+         "name" : "Tashkent"
+      },
+      "Tbilisi" : {
+         "countries" : [
+            "Georgia"
+         ],
+         "name" : "Tbilisi"
+      },
+      "Tegucigalpa" : {
+         "countries" : [
+            "Honduras"
+         ],
+         "name" : "Tegucigalpa"
+      },
+      "Tehran" : {
+         "countries" : [
+            "Iran"
+         ],
+         "name" : "Tehran"
+      },
+      "The Valley" : {
+         "countries" : [
+            "Anguilla"
+         ],
+         "name" : "The Valley"
+      },
+      "Thimphu" : {
+         "countries" : [
+            "Bhutan"
+         ],
+         "name" : "Thimphu"
+      },
+      "Tirana" : {
+         "countries" : [
+            "Albania"
+         ],
+         "name" : "Tirana"
+      },
+      "Tokyo" : {
+         "countries" : [
+            "Japan"
+         ],
+         "name" : "Tokyo"
+      },
+      "Tripoli" : {
+         "countries" : [
+            "Libya"
+         ],
+         "name" : "Tripoli"
+      },
+      "Tunis" : {
+         "countries" : [
+            "Tunisia"
+         ],
+         "name" : "Tunis"
+      },
+      "Tórshavn" : {
+         "countries" : [
+            "Faroe Islands"
+         ],
+         "name" : "Tórshavn"
+      },
+      "U.S. Minor Outlying Islands" : {
+         "countries" : [
+            "U.S. Minor Outlying Islands"
+         ],
+         "name" : "U.S. Minor Outlying Islands"
+      },
+      "Ulan Bator" : {
+         "countries" : [
+            "Mongolia"
+         ],
+         "name" : "Ulan Bator"
+      },
+      "Vaduz" : {
+         "countries" : [
+            "Liechtenstein"
+         ],
+         "name" : "Vaduz"
+      },
+      "Valletta" : {
+         "countries" : [
+            "Malta"
+         ],
+         "name" : "Valletta"
+      },
+      "Vatican City" : {
+         "countries" : [
+            "Vatican City"
+         ],
+         "name" : "Vatican City"
+      },
+      "Victoria" : {
+         "countries" : [
+            "Seychelles"
+         ],
+         "name" : "Victoria"
+      },
+      "Vienna" : {
+         "countries" : [
+            "Austria"
+         ],
+         "name" : "Vienna"
+      },
+      "Vientiane" : {
+         "countries" : [
+            "Laos"
+         ],
+         "name" : "Vientiane"
+      },
+      "Vilnius" : {
+         "countries" : [
+            "Lithuania"
+         ],
+         "name" : "Vilnius"
+      },
+      "Warsaw" : {
+         "countries" : [
+            "Poland"
+         ],
+         "name" : "Warsaw"
+      },
+      "Washington D.C." : {
+         "countries" : [
+            "United States"
+         ],
+         "name" : "Washington D.C."
+      },
+      "Wellington" : {
+         "countries" : [
+            "New Zealand"
+         ],
+         "name" : "Wellington"
+      },
+      "West Island" : {
+         "countries" : [
+            "Cocos [Keeling] Islands"
+         ],
+         "name" : "West Island"
+      },
+      "Willemstad" : {
+         "countries" : [
+            "Curacao"
+         ],
+         "name" : "Willemstad"
+      },
+      "Windhoek" : {
+         "countries" : [
+            "Namibia"
+         ],
+         "name" : "Windhoek"
+      },
+      "Yamoussoukro" : {
+         "countries" : [
+            "Ivory Coast"
+         ],
+         "name" : "Yamoussoukro"
+      },
+      "Yaoundé" : {
+         "countries" : [
+            "Cameroon"
+         ],
+         "name" : "Yaoundé"
+      },
+      "Yaren" : {
+         "countries" : [
+            "Nauru"
+         ],
+         "name" : "Yaren"
+      },
+      "Yerevan" : {
+         "countries" : [
+            "Armenia"
+         ],
+         "name" : "Yerevan"
+      },
+      "Zagreb" : {
+         "countries" : [
+            "Croatia"
+         ],
+         "name" : "Zagreb"
+      }
+   },
+   "continents" : {
+      "Africa" : {
+         "countries" : [
+            "Eritrea",
+            "Togo",
+            "Rwanda",
+            "Swaziland",
+            "São Tomé and Príncipe",
+            "Zimbabwe",
+            "Madagascar",
+            "Mauritius",
+            "Democratic Republic of the Congo",
+            "Kenya",
+            "Comoros",
+            "Ethiopia",
+            "Lesotho",
+            "Chad",
+            "Réunion",
+            "Zambia",
+            "Uganda",
+            "Senegal",
+            "Republic of the Congo",
+            "Ghana",
+            "South Africa",
+            "Mayotte",
+            "Angola",
+            "Burkina Faso",
+            "Central African Republic",
+            "Libya",
+            "Sierra Leone",
+            "Nigeria",
+            "Algeria",
+            "Equatorial Guinea",
+            "South Sudan",
+            "Seychelles",
+            "Liberia",
+            "Mali",
+            "Gabon",
+            "Djibouti",
+            "Morocco",
+            "Niger",
+            "Somalia",
+            "Namibia",
+            "Western Sahara",
+            "Tunisia",
+            "Cape Verde",
+            "Burundi",
+            "Mauritania",
+            "Guinea-Bissau",
+            "Egypt",
+            "Sudan",
+            "Benin",
+            "Saint Helena",
+            "Mozambique",
+            "Botswana",
+            "Gambia",
+            "Guinea",
+            "Malawi",
+            "Cameroon",
+            "Ivory Coast",
+            "Tanzania"
+         ],
+         "name" : "Africa"
+      },
+      "Antarctica" : {
+         "countries" : [
+            "South Georgia and the South Sandwich Islands",
+            "French Southern Territories",
+            "Heard Island and McDonald Islands",
+            "Antarctica",
+            "Bouvet Island"
+         ],
+         "name" : "Antarctica"
+      },
+      "Asia" : {
+         "countries" : [
+            "Hong Kong",
+            "Kuwait",
+            "Israel",
+            "Thailand",
+            "Bahrain",
+            "Kazakhstan",
+            "Malaysia",
+            "Christmas Island",
+            "Lebanon",
+            "Palestine",
+            "Bangladesh",
+            "Oman",
+            "South Korea",
+            "Iraq",
+            "Qatar",
+            "Saudi Arabia",
+            "Iran",
+            "Nepal",
+            "Afghanistan",
+            "Philippines",
+            "Macao",
+            "India",
+            "Cocos [Keeling] Islands",
+            "Yemen",
+            "Japan",
+            "Vietnam",
+            "Indonesia",
+            "Syria",
+            "Turkmenistan",
+            "Brunei",
+            "Uzbekistan",
+            "Turkey",
+            "British Indian Ocean Territory",
+            "Myanmar [Burma]",
+            "Mongolia",
+            "Armenia",
+            "United Arab Emirates",
+            "Tajikistan",
+            "North Korea",
+            "Sri Lanka",
+            "Maldives",
+            "Kyrgyzstan",
+            "Pakistan",
+            "Azerbaijan",
+            "Georgia",
+            "Taiwan",
+            "Jordan",
+            "Laos",
+            "Cambodia",
+            "Singapore",
+            "China",
+            "Bhutan"
+         ],
+         "name" : "Asia"
+      },
+      "Europe" : {
+         "countries" : [
+            "Bulgaria",
+            "Cyprus",
+            "Åland",
+            "Estonia",
+            "Svalbard and Jan Mayen",
+            "Guernsey",
+            "Faroe Islands",
+            "Switzerland",
+            "Slovenia",
+            "San Marino",
+            "Moldova",
+            "Andorra",
+            "Sweden",
+            "Norway",
+            "Belarus",
+            "Luxembourg",
+            "United Kingdom",
+            "Ireland",
+            "Slovakia",
+            "Isle of Man",
+            "Italy",
+            "Croatia",
+            "Jersey",
+            "Monaco",
+            "Kosovo",
+            "Serbia",
+            "Ukraine",
+            "Liechtenstein",
+            "Albania",
+            "Hungary",
+            "Finland",
+            "Romania",
+            "Spain",
+            "Germany",
+            "Lithuania",
+            "Bosnia and Herzegovina",
+            "Latvia",
+            "North Macedonia",
+            "Portugal",
+            "France",
+            "Belgium",
+            "Poland",
+            "Czech Republic",
+            "Montenegro",
+            "Vatican City",
+            "Denmark",
+            "Austria",
+            "Malta",
+            "Russia",
+            "Gibraltar",
+            "Greece",
+            "Netherlands",
+            "Iceland"
+         ],
+         "name" : "Europe"
+      },
+      "North America" : {
+         "countries" : [
+            "El Salvador",
+            "Grenada",
+            "Saint Vincent and the Grenadines",
+            "Mexico",
+            "Guadeloupe",
+            "Antigua and Barbuda",
+            "Saint Lucia",
+            "Saint Kitts and Nevis",
+            "Cuba",
+            "Dominican Republic",
+            "Saint Martin",
+            "United States",
+            "Haiti",
+            "British Virgin Islands",
+            "Honduras",
+            "Bahamas",
+            "Barbados",
+            "Turks and Caicos Islands",
+            "Montserrat",
+            "Jamaica",
+            "Saint Barthélemy",
+            "Saint Pierre and Miquelon",
+            "Canada",
+            "Puerto Rico",
+            "Greenland",
+            "U.S. Virgin Islands",
+            "Bonaire",
+            "Nicaragua",
+            "Dominica",
+            "Martinique",
+            "Bermuda",
+            "Anguilla",
+            "Curacao",
+            "Guatemala",
+            "Cayman Islands",
+            "Costa Rica",
+            "Sint Maarten",
+            "Aruba",
+            "Panama",
+            "Trinidad and Tobago",
+            "Belize"
+         ],
+         "name" : "North America"
+      },
+      "Oceania" : {
+         "countries" : [
+            "Marshall Islands",
+            "New Caledonia",
+            "Australia",
+            "French Polynesia",
+            "Northern Mariana Islands",
+            "Guam",
+            "Norfolk Island",
+            "Kiribati",
+            "Wallis and Futuna",
+            "Papua New Guinea",
+            "Tonga",
+            "Vanuatu",
+            "American Samoa",
+            "Samoa",
+            "Niue",
+            "East Timor",
+            "New Zealand",
+            "Pitcairn Islands",
+            "Solomon Islands",
+            "Cook Islands",
+            "Micronesia",
+            "Tokelau",
+            "Nauru",
+            "Palau",
+            "Fiji",
+            "U.S. Minor Outlying Islands",
+            "Tuvalu"
+         ],
+         "name" : "Oceania"
+      },
+      "South America" : {
+         "countries" : [
+            "Uruguay",
+            "Guyana",
+            "Suriname",
+            "Bolivia",
+            "Colombia",
+            "French Guiana",
+            "Paraguay",
+            "Peru",
+            "Venezuela",
+            "Chile",
+            "Ecuador",
+            "Falkland Islands",
+            "Argentina",
+            "Brazil"
+         ],
+         "name" : "South America"
+      }
+   },
+   "countries" : {
+      "Afghanistan" : {
+         "cities" : [
+            "Kabul"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "AFN"
+         ],
+         "name" : "Afghanistan"
+      },
+      "Albania" : {
+         "cities" : [
+            "Tirana"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "ALL"
+         ],
+         "name" : "Albania"
+      },
+      "Algeria" : {
+         "cities" : [
+            "Algiers"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "DZD"
+         ],
+         "name" : "Algeria"
+      },
+      "American Samoa" : {
+         "cities" : [
+            "Pago Pago"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "USD"
+         ],
+         "name" : "American Samoa"
+      },
+      "Andorra" : {
+         "cities" : [
+            "Andorra la Vella"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Andorra"
+      },
+      "Angola" : {
+         "cities" : [
+            "Luanda"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "AOA"
+         ],
+         "name" : "Angola"
+      },
+      "Anguilla" : {
+         "cities" : [
+            "The Valley"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "XCD"
+         ],
+         "name" : "Anguilla"
+      },
+      "Antarctica" : {
+         "cities" : [
+            "Antarctica"
+         ],
+         "continent" : "Antarctica",
+         "currency" : [],
+         "name" : "Antarctica"
+      },
+      "Antigua and Barbuda" : {
+         "cities" : [
+            "Saint John's"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "XCD"
+         ],
+         "name" : "Antigua and Barbuda"
+      },
+      "Argentina" : {
+         "cities" : [
+            "Buenos Aires"
+         ],
+         "continent" : "South America",
+         "currency" : [
+            "ARS"
+         ],
+         "name" : "Argentina"
+      },
+      "Armenia" : {
+         "cities" : [
+            "Yerevan"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "AMD"
+         ],
+         "name" : "Armenia"
+      },
+      "Aruba" : {
+         "cities" : [
+            "Oranjestad"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "AWG"
+         ],
+         "name" : "Aruba"
+      },
+      "Australia" : {
+         "cities" : [
+            "Canberra"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "AUD"
+         ],
+         "name" : "Australia"
+      },
+      "Austria" : {
+         "cities" : [
+            "Vienna"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Austria"
+      },
+      "Azerbaijan" : {
+         "cities" : [
+            "Baku"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "AZN"
+         ],
+         "name" : "Azerbaijan"
+      },
+      "Bahamas" : {
+         "cities" : [
+            "Nassau"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "BSD"
+         ],
+         "name" : "Bahamas"
+      },
+      "Bahrain" : {
+         "cities" : [
+            "Manama"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "BHD"
+         ],
+         "name" : "Bahrain"
+      },
+      "Bangladesh" : {
+         "cities" : [
+            "Dhaka"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "BDT"
+         ],
+         "name" : "Bangladesh"
+      },
+      "Barbados" : {
+         "cities" : [
+            "Bridgetown"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "BBD"
+         ],
+         "name" : "Barbados"
+      },
+      "Belarus" : {
+         "cities" : [
+            "Minsk"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "BYN"
+         ],
+         "name" : "Belarus"
+      },
+      "Belgium" : {
+         "cities" : [
+            "Brussels"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Belgium"
+      },
+      "Belize" : {
+         "cities" : [
+            "Belmopan"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "BZD"
+         ],
+         "name" : "Belize"
+      },
+      "Benin" : {
+         "cities" : [
+            "Porto-Novo"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "XOF"
+         ],
+         "name" : "Benin"
+      },
+      "Bermuda" : {
+         "cities" : [
+            "Hamilton"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "BMD"
+         ],
+         "name" : "Bermuda"
+      },
+      "Bhutan" : {
+         "cities" : [
+            "Thimphu"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "BTN",
+            "INR"
+         ],
+         "name" : "Bhutan"
+      },
+      "Bolivia" : {
+         "cities" : [
+            "Sucre"
+         ],
+         "continent" : "South America",
+         "currency" : [
+            "BOB",
+            "BOV"
+         ],
+         "name" : "Bolivia"
+      },
+      "Bonaire" : {
+         "cities" : [
+            "Kralendijk"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "USD"
+         ],
+         "name" : "Bonaire"
+      },
+      "Bosnia and Herzegovina" : {
+         "cities" : [
+            "Sarajevo"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "BAM"
+         ],
+         "name" : "Bosnia and Herzegovina"
+      },
+      "Botswana" : {
+         "cities" : [
+            "Gaborone"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "BWP"
+         ],
+         "name" : "Botswana"
+      },
+      "Bouvet Island" : {
+         "cities" : [
+            "Bouvet Island"
+         ],
+         "continent" : "Antarctica",
+         "currency" : [
+            "NOK"
+         ],
+         "name" : "Bouvet Island"
+      },
+      "Brazil" : {
+         "cities" : [
+            "Brasília"
+         ],
+         "continent" : "South America",
+         "currency" : [
+            "BRL"
+         ],
+         "name" : "Brazil"
+      },
+      "British Indian Ocean Territory" : {
+         "cities" : [
+            "Diego Garcia"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "USD"
+         ],
+         "name" : "British Indian Ocean Territory"
+      },
+      "British Virgin Islands" : {
+         "cities" : [
+            "Road Town"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "USD"
+         ],
+         "name" : "British Virgin Islands"
+      },
+      "Brunei" : {
+         "cities" : [
+            "Bandar Seri Begawan"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "BND"
+         ],
+         "name" : "Brunei"
+      },
+      "Bulgaria" : {
+         "cities" : [
+            "Sofia"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "BGN"
+         ],
+         "name" : "Bulgaria"
+      },
+      "Burkina Faso" : {
+         "cities" : [
+            "Ouagadougou"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "XOF"
+         ],
+         "name" : "Burkina Faso"
+      },
+      "Burundi" : {
+         "cities" : [
+            "Bujumbura"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "BIF"
+         ],
+         "name" : "Burundi"
+      },
+      "Cambodia" : {
+         "cities" : [
+            "Phnom Penh"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "KHR"
+         ],
+         "name" : "Cambodia"
+      },
+      "Cameroon" : {
+         "cities" : [
+            "Yaoundé"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "XAF"
+         ],
+         "name" : "Cameroon"
+      },
+      "Canada" : {
+         "cities" : [
+            "Ottawa"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "CAD"
+         ],
+         "name" : "Canada"
+      },
+      "Cape Verde" : {
+         "cities" : [
+            "Praia"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "CVE"
+         ],
+         "name" : "Cape Verde"
+      },
+      "Cayman Islands" : {
+         "cities" : [
+            "George Town"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "KYD"
+         ],
+         "name" : "Cayman Islands"
+      },
+      "Central African Republic" : {
+         "cities" : [
+            "Bangui"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "XAF"
+         ],
+         "name" : "Central African Republic"
+      },
+      "Chad" : {
+         "cities" : [
+            "N'Djamena"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "XAF"
+         ],
+         "name" : "Chad"
+      },
+      "Chile" : {
+         "cities" : [
+            "Santiago"
+         ],
+         "continent" : "South America",
+         "currency" : [
+            "CLF",
+            "CLP"
+         ],
+         "name" : "Chile"
+      },
+      "China" : {
+         "cities" : [
+            "Beijing"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "CNY"
+         ],
+         "name" : "China"
+      },
+      "Christmas Island" : {
+         "cities" : [
+            "Flying Fish Cove"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "AUD"
+         ],
+         "name" : "Christmas Island"
+      },
+      "Cocos [Keeling] Islands" : {
+         "cities" : [
+            "West Island"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "AUD"
+         ],
+         "name" : "Cocos [Keeling] Islands"
+      },
+      "Colombia" : {
+         "cities" : [
+            "Bogotá"
+         ],
+         "continent" : "South America",
+         "currency" : [
+            "COP"
+         ],
+         "name" : "Colombia"
+      },
+      "Comoros" : {
+         "cities" : [
+            "Moroni"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "KMF"
+         ],
+         "name" : "Comoros"
+      },
+      "Cook Islands" : {
+         "cities" : [
+            "Avarua"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "NZD"
+         ],
+         "name" : "Cook Islands"
+      },
+      "Costa Rica" : {
+         "cities" : [
+            "San José"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "CRC"
+         ],
+         "name" : "Costa Rica"
+      },
+      "Croatia" : {
+         "cities" : [
+            "Zagreb"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "HRK"
+         ],
+         "name" : "Croatia"
+      },
+      "Cuba" : {
+         "cities" : [
+            "Havana"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "CUC",
+            "CUP"
+         ],
+         "name" : "Cuba"
+      },
+      "Curacao" : {
+         "cities" : [
+            "Willemstad"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "ANG"
+         ],
+         "name" : "Curacao"
+      },
+      "Cyprus" : {
+         "cities" : [
+            "Nicosia"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Cyprus"
+      },
+      "Czech Republic" : {
+         "cities" : [
+            "Prague"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "CZK"
+         ],
+         "name" : "Czech Republic"
+      },
+      "Democratic Republic of the Congo" : {
+         "cities" : [
+            "Kinshasa"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "CDF"
+         ],
+         "name" : "Democratic Republic of the Congo"
+      },
+      "Denmark" : {
+         "cities" : [
+            "Copenhagen"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "DKK"
+         ],
+         "name" : "Denmark"
+      },
+      "Djibouti" : {
+         "cities" : [
+            "Djibouti"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "DJF"
+         ],
+         "name" : "Djibouti"
+      },
+      "Dominica" : {
+         "cities" : [
+            "Roseau"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "XCD"
+         ],
+         "name" : "Dominica"
+      },
+      "Dominican Republic" : {
+         "cities" : [
+            "Santo Domingo"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "DOP"
+         ],
+         "name" : "Dominican Republic"
+      },
+      "East Timor" : {
+         "cities" : [
+            "Dili"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "USD"
+         ],
+         "name" : "East Timor"
+      },
+      "Ecuador" : {
+         "cities" : [
+            "Quito"
+         ],
+         "continent" : "South America",
+         "currency" : [
+            "USD"
+         ],
+         "name" : "Ecuador"
+      },
+      "Egypt" : {
+         "cities" : [
+            "Cairo"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "EGP"
+         ],
+         "name" : "Egypt"
+      },
+      "El Salvador" : {
+         "cities" : [
+            "San Salvador"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "SVC",
+            "USD"
+         ],
+         "name" : "El Salvador"
+      },
+      "Equatorial Guinea" : {
+         "cities" : [
+            "Malabo"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "XAF"
+         ],
+         "name" : "Equatorial Guinea"
+      },
+      "Eritrea" : {
+         "cities" : [
+            "Asmara"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "ERN"
+         ],
+         "name" : "Eritrea"
+      },
+      "Estonia" : {
+         "cities" : [
+            "Tallinn"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Estonia"
+      },
+      "Ethiopia" : {
+         "cities" : [
+            "Addis Ababa"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "ETB"
+         ],
+         "name" : "Ethiopia"
+      },
+      "Falkland Islands" : {
+         "cities" : [
+            "Stanley"
+         ],
+         "continent" : "South America",
+         "currency" : [
+            "FKP"
+         ],
+         "name" : "Falkland Islands"
+      },
+      "Faroe Islands" : {
+         "cities" : [
+            "Tórshavn"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "DKK"
+         ],
+         "name" : "Faroe Islands"
+      },
+      "Fiji" : {
+         "cities" : [
+            "Suva"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "FJD"
+         ],
+         "name" : "Fiji"
+      },
+      "Finland" : {
+         "cities" : [
+            "Helsinki"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Finland"
+      },
+      "France" : {
+         "cities" : [
+            "Paris"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "France"
+      },
+      "French Guiana" : {
+         "cities" : [
+            "Cayenne"
+         ],
+         "continent" : "South America",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "French Guiana"
+      },
+      "French Polynesia" : {
+         "cities" : [
+            "Papeetē"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "XPF"
+         ],
+         "name" : "French Polynesia"
+      },
+      "French Southern Territories" : {
+         "cities" : [
+            "Port-aux-Français"
+         ],
+         "continent" : "Antarctica",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "French Southern Territories"
+      },
+      "Gabon" : {
+         "cities" : [
+            "Libreville"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "XAF"
+         ],
+         "name" : "Gabon"
+      },
+      "Gambia" : {
+         "cities" : [
+            "Banjul"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "GMD"
+         ],
+         "name" : "Gambia"
+      },
+      "Georgia" : {
+         "cities" : [
+            "Tbilisi"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "GEL"
+         ],
+         "name" : "Georgia"
+      },
+      "Germany" : {
+         "cities" : [
+            "Berlin"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Germany"
+      },
+      "Ghana" : {
+         "cities" : [
+            "Accra"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "GHS"
+         ],
+         "name" : "Ghana"
+      },
+      "Gibraltar" : {
+         "cities" : [
+            "Gibraltar"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "GIP"
+         ],
+         "name" : "Gibraltar"
+      },
+      "Greece" : {
+         "cities" : [
+            "Athens"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Greece"
+      },
+      "Greenland" : {
+         "cities" : [
+            "Nuuk"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "DKK"
+         ],
+         "name" : "Greenland"
+      },
+      "Grenada" : {
+         "cities" : [
+            "St. George's"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "XCD"
+         ],
+         "name" : "Grenada"
+      },
+      "Guadeloupe" : {
+         "cities" : [
+            "Basse-Terre"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Guadeloupe"
+      },
+      "Guam" : {
+         "cities" : [
+            "Hagåtña"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "USD"
+         ],
+         "name" : "Guam"
+      },
+      "Guatemala" : {
+         "cities" : [
+            "Guatemala City"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "GTQ"
+         ],
+         "name" : "Guatemala"
+      },
+      "Guernsey" : {
+         "cities" : [
+            "St. Peter Port"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "GBP"
+         ],
+         "name" : "Guernsey"
+      },
+      "Guinea" : {
+         "cities" : [
+            "Conakry"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "GNF"
+         ],
+         "name" : "Guinea"
+      },
+      "Guinea-Bissau" : {
+         "cities" : [
+            "Bissau"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "XOF"
+         ],
+         "name" : "Guinea-Bissau"
+      },
+      "Guyana" : {
+         "cities" : [
+            "Georgetown"
+         ],
+         "continent" : "South America",
+         "currency" : [
+            "GYD"
+         ],
+         "name" : "Guyana"
+      },
+      "Haiti" : {
+         "cities" : [
+            "Port-au-Prince"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "HTG",
+            "USD"
+         ],
+         "name" : "Haiti"
+      },
+      "Heard Island and McDonald Islands" : {
+         "cities" : [
+            "Heard Island and McDonald Islands"
+         ],
+         "continent" : "Antarctica",
+         "currency" : [
+            "AUD"
+         ],
+         "name" : "Heard Island and McDonald Islands"
+      },
+      "Honduras" : {
+         "cities" : [
+            "Tegucigalpa"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "HNL"
+         ],
+         "name" : "Honduras"
+      },
+      "Hong Kong" : {
+         "cities" : [
+            "City of Victoria"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "HKD"
+         ],
+         "name" : "Hong Kong"
+      },
+      "Hungary" : {
+         "cities" : [
+            "Budapest"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "HUF"
+         ],
+         "name" : "Hungary"
+      },
+      "Iceland" : {
+         "cities" : [
+            "Reykjavik"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "ISK"
+         ],
+         "name" : "Iceland"
+      },
+      "India" : {
+         "cities" : [
+            "New Delhi"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "INR"
+         ],
+         "name" : "India"
+      },
+      "Indonesia" : {
+         "cities" : [
+            "Jakarta"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "IDR"
+         ],
+         "name" : "Indonesia"
+      },
+      "Iran" : {
+         "cities" : [
+            "Tehran"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "IRR"
+         ],
+         "name" : "Iran"
+      },
+      "Iraq" : {
+         "cities" : [
+            "Baghdad"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "IQD"
+         ],
+         "name" : "Iraq"
+      },
+      "Ireland" : {
+         "cities" : [
+            "Dublin"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Ireland"
+      },
+      "Isle of Man" : {
+         "cities" : [
+            "Douglas"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "GBP"
+         ],
+         "name" : "Isle of Man"
+      },
+      "Israel" : {
+         "cities" : [
+            "Jerusalem"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "ILS"
+         ],
+         "name" : "Israel"
+      },
+      "Italy" : {
+         "cities" : [
+            "Rome"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Italy"
+      },
+      "Ivory Coast" : {
+         "cities" : [
+            "Yamoussoukro"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "XOF"
+         ],
+         "name" : "Ivory Coast"
+      },
+      "Jamaica" : {
+         "cities" : [
+            "Kingston"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "JMD"
+         ],
+         "name" : "Jamaica"
+      },
+      "Japan" : {
+         "cities" : [
+            "Tokyo"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "JPY"
+         ],
+         "name" : "Japan"
+      },
+      "Jersey" : {
+         "cities" : [
+            "Saint Helier"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "GBP"
+         ],
+         "name" : "Jersey"
+      },
+      "Jordan" : {
+         "cities" : [
+            "Amman"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "JOD"
+         ],
+         "name" : "Jordan"
+      },
+      "Kazakhstan" : {
+         "cities" : [
+            "Astana"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "KZT"
+         ],
+         "name" : "Kazakhstan"
+      },
+      "Kenya" : {
+         "cities" : [
+            "Nairobi"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "KES"
+         ],
+         "name" : "Kenya"
+      },
+      "Kiribati" : {
+         "cities" : [
+            "South Tarawa"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "AUD"
+         ],
+         "name" : "Kiribati"
+      },
+      "Kosovo" : {
+         "cities" : [
+            "Pristina"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Kosovo"
+      },
+      "Kuwait" : {
+         "cities" : [
+            "Kuwait City"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "KWD"
+         ],
+         "name" : "Kuwait"
+      },
+      "Kyrgyzstan" : {
+         "cities" : [
+            "Bishkek"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "KGS"
+         ],
+         "name" : "Kyrgyzstan"
+      },
+      "Laos" : {
+         "cities" : [
+            "Vientiane"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "LAK"
+         ],
+         "name" : "Laos"
+      },
+      "Latvia" : {
+         "cities" : [
+            "Riga"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Latvia"
+      },
+      "Lebanon" : {
+         "cities" : [
+            "Beirut"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "LBP"
+         ],
+         "name" : "Lebanon"
+      },
+      "Lesotho" : {
+         "cities" : [
+            "Maseru"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "LSL",
+            "ZAR"
+         ],
+         "name" : "Lesotho"
+      },
+      "Liberia" : {
+         "cities" : [
+            "Monrovia"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "LRD"
+         ],
+         "name" : "Liberia"
+      },
+      "Libya" : {
+         "cities" : [
+            "Tripoli"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "LYD"
+         ],
+         "name" : "Libya"
+      },
+      "Liechtenstein" : {
+         "cities" : [
+            "Vaduz"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "CHF"
+         ],
+         "name" : "Liechtenstein"
+      },
+      "Lithuania" : {
+         "cities" : [
+            "Vilnius"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Lithuania"
+      },
+      "Luxembourg" : {
+         "cities" : [
+            "Luxembourg"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Luxembourg"
+      },
+      "Macao" : {
+         "cities" : [
+            "Macao"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "MOP"
+         ],
+         "name" : "Macao"
+      },
+      "Madagascar" : {
+         "cities" : [
+            "Antananarivo"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "MGA"
+         ],
+         "name" : "Madagascar"
+      },
+      "Malawi" : {
+         "cities" : [
+            "Lilongwe"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "MWK"
+         ],
+         "name" : "Malawi"
+      },
+      "Malaysia" : {
+         "cities" : [
+            "Kuala Lumpur"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "MYR"
+         ],
+         "name" : "Malaysia"
+      },
+      "Maldives" : {
+         "cities" : [
+            "Malé"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "MVR"
+         ],
+         "name" : "Maldives"
+      },
+      "Mali" : {
+         "cities" : [
+            "Bamako"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "XOF"
+         ],
+         "name" : "Mali"
+      },
+      "Malta" : {
+         "cities" : [
+            "Valletta"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Malta"
+      },
+      "Marshall Islands" : {
+         "cities" : [
+            "Majuro"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "USD"
+         ],
+         "name" : "Marshall Islands"
+      },
+      "Martinique" : {
+         "cities" : [
+            "Fort-de-France"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Martinique"
+      },
+      "Mauritania" : {
+         "cities" : [
+            "Nouakchott"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "MRU"
+         ],
+         "name" : "Mauritania"
+      },
+      "Mauritius" : {
+         "cities" : [
+            "Port Louis"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "MUR"
+         ],
+         "name" : "Mauritius"
+      },
+      "Mayotte" : {
+         "cities" : [
+            "Mamoudzou"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Mayotte"
+      },
+      "Mexico" : {
+         "cities" : [
+            "Mexico City"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "MXN"
+         ],
+         "name" : "Mexico"
+      },
+      "Micronesia" : {
+         "cities" : [
+            "Palikir"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "USD"
+         ],
+         "name" : "Micronesia"
+      },
+      "Moldova" : {
+         "cities" : [
+            "Chișinău"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "MDL"
+         ],
+         "name" : "Moldova"
+      },
+      "Monaco" : {
+         "cities" : [
+            "Monaco"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Monaco"
+      },
+      "Mongolia" : {
+         "cities" : [
+            "Ulan Bator"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "MNT"
+         ],
+         "name" : "Mongolia"
+      },
+      "Montenegro" : {
+         "cities" : [
+            "Podgorica"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Montenegro"
+      },
+      "Montserrat" : {
+         "cities" : [
+            "Plymouth"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "XCD"
+         ],
+         "name" : "Montserrat"
+      },
+      "Morocco" : {
+         "cities" : [
+            "Rabat"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "MAD"
+         ],
+         "name" : "Morocco"
+      },
+      "Mozambique" : {
+         "cities" : [
+            "Maputo"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "MZN"
+         ],
+         "name" : "Mozambique"
+      },
+      "Myanmar [Burma]" : {
+         "cities" : [
+            "Naypyidaw"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "MMK"
+         ],
+         "name" : "Myanmar [Burma]"
+      },
+      "Namibia" : {
+         "cities" : [
+            "Windhoek"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "NAD",
+            "ZAR"
+         ],
+         "name" : "Namibia"
+      },
+      "Nauru" : {
+         "cities" : [
+            "Yaren"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "AUD"
+         ],
+         "name" : "Nauru"
+      },
+      "Nepal" : {
+         "cities" : [
+            "Kathmandu"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "NPR"
+         ],
+         "name" : "Nepal"
+      },
+      "Netherlands" : {
+         "cities" : [
+            "Amsterdam"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Netherlands"
+      },
+      "New Caledonia" : {
+         "cities" : [
+            "Nouméa"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "XPF"
+         ],
+         "name" : "New Caledonia"
+      },
+      "New Zealand" : {
+         "cities" : [
+            "Wellington"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "NZD"
+         ],
+         "name" : "New Zealand"
+      },
+      "Nicaragua" : {
+         "cities" : [
+            "Managua"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "NIO"
+         ],
+         "name" : "Nicaragua"
+      },
+      "Niger" : {
+         "cities" : [
+            "Niamey"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "XOF"
+         ],
+         "name" : "Niger"
+      },
+      "Nigeria" : {
+         "cities" : [
+            "Abuja"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "NGN"
+         ],
+         "name" : "Nigeria"
+      },
+      "Niue" : {
+         "cities" : [
+            "Alofi"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "NZD"
+         ],
+         "name" : "Niue"
+      },
+      "Norfolk Island" : {
+         "cities" : [
+            "Kingston"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "AUD"
+         ],
+         "name" : "Norfolk Island"
+      },
+      "North Korea" : {
+         "cities" : [
+            "Pyongyang"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "KPW"
+         ],
+         "name" : "North Korea"
+      },
+      "North Macedonia" : {
+         "cities" : [
+            "Skopje"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "MKD"
+         ],
+         "name" : "North Macedonia"
+      },
+      "Northern Mariana Islands" : {
+         "cities" : [
+            "Saipan"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "USD"
+         ],
+         "name" : "Northern Mariana Islands"
+      },
+      "Norway" : {
+         "cities" : [
+            "Oslo"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "NOK"
+         ],
+         "name" : "Norway"
+      },
+      "Oman" : {
+         "cities" : [
+            "Muscat"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "OMR"
+         ],
+         "name" : "Oman"
+      },
+      "Pakistan" : {
+         "cities" : [
+            "Islamabad"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "PKR"
+         ],
+         "name" : "Pakistan"
+      },
+      "Palau" : {
+         "cities" : [
+            "Ngerulmud"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "USD"
+         ],
+         "name" : "Palau"
+      },
+      "Palestine" : {
+         "cities" : [
+            "Ramallah"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "ILS"
+         ],
+         "name" : "Palestine"
+      },
+      "Panama" : {
+         "cities" : [
+            "Panama City"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "PAB",
+            "USD"
+         ],
+         "name" : "Panama"
+      },
+      "Papua New Guinea" : {
+         "cities" : [
+            "Port Moresby"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "PGK"
+         ],
+         "name" : "Papua New Guinea"
+      },
+      "Paraguay" : {
+         "cities" : [
+            "Asunción"
+         ],
+         "continent" : "South America",
+         "currency" : [
+            "PYG"
+         ],
+         "name" : "Paraguay"
+      },
+      "Peru" : {
+         "cities" : [
+            "Lima"
+         ],
+         "continent" : "South America",
+         "currency" : [
+            "PEN"
+         ],
+         "name" : "Peru"
+      },
+      "Philippines" : {
+         "cities" : [
+            "Manila"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "PHP"
+         ],
+         "name" : "Philippines"
+      },
+      "Pitcairn Islands" : {
+         "cities" : [
+            "Adamstown"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "NZD"
+         ],
+         "name" : "Pitcairn Islands"
+      },
+      "Poland" : {
+         "cities" : [
+            "Warsaw"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "PLN"
+         ],
+         "name" : "Poland"
+      },
+      "Portugal" : {
+         "cities" : [
+            "Lisbon"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Portugal"
+      },
+      "Puerto Rico" : {
+         "cities" : [
+            "San Juan"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "USD"
+         ],
+         "name" : "Puerto Rico"
+      },
+      "Qatar" : {
+         "cities" : [
+            "Doha"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "QAR"
+         ],
+         "name" : "Qatar"
+      },
+      "Republic of the Congo" : {
+         "cities" : [
+            "Brazzaville"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "XAF"
+         ],
+         "name" : "Republic of the Congo"
+      },
+      "Romania" : {
+         "cities" : [
+            "Bucharest"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "RON"
+         ],
+         "name" : "Romania"
+      },
+      "Russia" : {
+         "cities" : [
+            "Moscow"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "RUB"
+         ],
+         "name" : "Russia"
+      },
+      "Rwanda" : {
+         "cities" : [
+            "Kigali"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "RWF"
+         ],
+         "name" : "Rwanda"
+      },
+      "Réunion" : {
+         "cities" : [
+            "Saint-Denis"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Réunion"
+      },
+      "Saint Barthélemy" : {
+         "cities" : [
+            "Gustavia"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Saint Barthélemy"
+      },
+      "Saint Helena" : {
+         "cities" : [
+            "Jamestown"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "SHP"
+         ],
+         "name" : "Saint Helena"
+      },
+      "Saint Kitts and Nevis" : {
+         "cities" : [
+            "Basseterre"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "XCD"
+         ],
+         "name" : "Saint Kitts and Nevis"
+      },
+      "Saint Lucia" : {
+         "cities" : [
+            "Castries"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "XCD"
+         ],
+         "name" : "Saint Lucia"
+      },
+      "Saint Martin" : {
+         "cities" : [
+            "Marigot"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Saint Martin"
+      },
+      "Saint Pierre and Miquelon" : {
+         "cities" : [
+            "Saint-Pierre"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Saint Pierre and Miquelon"
+      },
+      "Saint Vincent and the Grenadines" : {
+         "cities" : [
+            "Kingstown"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "XCD"
+         ],
+         "name" : "Saint Vincent and the Grenadines"
+      },
+      "Samoa" : {
+         "cities" : [
+            "Apia"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "WST"
+         ],
+         "name" : "Samoa"
+      },
+      "San Marino" : {
+         "cities" : [
+            "City of San Marino"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "San Marino"
+      },
+      "Saudi Arabia" : {
+         "cities" : [
+            "Riyadh"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "SAR"
+         ],
+         "name" : "Saudi Arabia"
+      },
+      "Senegal" : {
+         "cities" : [
+            "Dakar"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "XOF"
+         ],
+         "name" : "Senegal"
+      },
+      "Serbia" : {
+         "cities" : [
+            "Belgrade"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "RSD"
+         ],
+         "name" : "Serbia"
+      },
+      "Seychelles" : {
+         "cities" : [
+            "Victoria"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "SCR"
+         ],
+         "name" : "Seychelles"
+      },
+      "Sierra Leone" : {
+         "cities" : [
+            "Freetown"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "SLL"
+         ],
+         "name" : "Sierra Leone"
+      },
+      "Singapore" : {
+         "cities" : [
+            "Singapore"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "SGD"
+         ],
+         "name" : "Singapore"
+      },
+      "Sint Maarten" : {
+         "cities" : [
+            "Philipsburg"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "ANG"
+         ],
+         "name" : "Sint Maarten"
+      },
+      "Slovakia" : {
+         "cities" : [
+            "Bratislava"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Slovakia"
+      },
+      "Slovenia" : {
+         "cities" : [
+            "Ljubljana"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Slovenia"
+      },
+      "Solomon Islands" : {
+         "cities" : [
+            "Honiara"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "SBD"
+         ],
+         "name" : "Solomon Islands"
+      },
+      "Somalia" : {
+         "cities" : [
+            "Mogadishu"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "SOS"
+         ],
+         "name" : "Somalia"
+      },
+      "South Africa" : {
+         "cities" : [
+            "Pretoria"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "ZAR"
+         ],
+         "name" : "South Africa"
+      },
+      "South Georgia and the South Sandwich Islands" : {
+         "cities" : [
+            "King Edward Point"
+         ],
+         "continent" : "Antarctica",
+         "currency" : [
+            "GBP"
+         ],
+         "name" : "South Georgia and the South Sandwich Islands"
+      },
+      "South Korea" : {
+         "cities" : [
+            "Seoul"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "KRW"
+         ],
+         "name" : "South Korea"
+      },
+      "South Sudan" : {
+         "cities" : [
+            "Juba"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "SSP"
+         ],
+         "name" : "South Sudan"
+      },
+      "Spain" : {
+         "cities" : [
+            "Madrid"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Spain"
+      },
+      "Sri Lanka" : {
+         "cities" : [
+            "Colombo"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "LKR"
+         ],
+         "name" : "Sri Lanka"
+      },
+      "Sudan" : {
+         "cities" : [
+            "Khartoum"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "SDG"
+         ],
+         "name" : "Sudan"
+      },
+      "Suriname" : {
+         "cities" : [
+            "Paramaribo"
+         ],
+         "continent" : "South America",
+         "currency" : [
+            "SRD"
+         ],
+         "name" : "Suriname"
+      },
+      "Svalbard and Jan Mayen" : {
+         "cities" : [
+            "Longyearbyen"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "NOK"
+         ],
+         "name" : "Svalbard and Jan Mayen"
+      },
+      "Swaziland" : {
+         "cities" : [
+            "Lobamba"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "SZL"
+         ],
+         "name" : "Swaziland"
+      },
+      "Sweden" : {
+         "cities" : [
+            "Stockholm"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "SEK"
+         ],
+         "name" : "Sweden"
+      },
+      "Switzerland" : {
+         "cities" : [
+            "Bern"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "CHE",
+            "CHF",
+            "CHW"
+         ],
+         "name" : "Switzerland"
+      },
+      "Syria" : {
+         "cities" : [
+            "Damascus"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "SYP"
+         ],
+         "name" : "Syria"
+      },
+      "São Tomé and Príncipe" : {
+         "cities" : [
+            "São Tomé"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "STN"
+         ],
+         "name" : "São Tomé and Príncipe"
+      },
+      "Taiwan" : {
+         "cities" : [
+            "Taipei"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "TWD"
+         ],
+         "name" : "Taiwan"
+      },
+      "Tajikistan" : {
+         "cities" : [
+            "Dushanbe"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "TJS"
+         ],
+         "name" : "Tajikistan"
+      },
+      "Tanzania" : {
+         "cities" : [
+            "Dodoma"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "TZS"
+         ],
+         "name" : "Tanzania"
+      },
+      "Thailand" : {
+         "cities" : [
+            "Bangkok"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "THB"
+         ],
+         "name" : "Thailand"
+      },
+      "Togo" : {
+         "cities" : [
+            "Lomé"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "XOF"
+         ],
+         "name" : "Togo"
+      },
+      "Tokelau" : {
+         "cities" : [
+            "Fakaofo"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "NZD"
+         ],
+         "name" : "Tokelau"
+      },
+      "Tonga" : {
+         "cities" : [
+            "Nuku'alofa"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "TOP"
+         ],
+         "name" : "Tonga"
+      },
+      "Trinidad and Tobago" : {
+         "cities" : [
+            "Port of Spain"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "TTD"
+         ],
+         "name" : "Trinidad and Tobago"
+      },
+      "Tunisia" : {
+         "cities" : [
+            "Tunis"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "TND"
+         ],
+         "name" : "Tunisia"
+      },
+      "Turkey" : {
+         "cities" : [
+            "Ankara"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "TRY"
+         ],
+         "name" : "Turkey"
+      },
+      "Turkmenistan" : {
+         "cities" : [
+            "Ashgabat"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "TMT"
+         ],
+         "name" : "Turkmenistan"
+      },
+      "Turks and Caicos Islands" : {
+         "cities" : [
+            "Cockburn Town"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "USD"
+         ],
+         "name" : "Turks and Caicos Islands"
+      },
+      "Tuvalu" : {
+         "cities" : [
+            "Funafuti"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "AUD"
+         ],
+         "name" : "Tuvalu"
+      },
+      "U.S. Minor Outlying Islands" : {
+         "cities" : [
+            "U.S. Minor Outlying Islands"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "USD"
+         ],
+         "name" : "U.S. Minor Outlying Islands"
+      },
+      "U.S. Virgin Islands" : {
+         "cities" : [
+            "Charlotte Amalie"
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "USD"
+         ],
+         "name" : "U.S. Virgin Islands"
+      },
+      "Uganda" : {
+         "cities" : [
+            "Kampala"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "UGX"
+         ],
+         "name" : "Uganda"
+      },
+      "Ukraine" : {
+         "cities" : [
+            "Kyiv"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "UAH"
+         ],
+         "name" : "Ukraine"
+      },
+      "United Arab Emirates" : {
+         "cities" : [
+            "Abu Dhabi"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "AED"
+         ],
+         "name" : "United Arab Emirates"
+      },
+      "United Kingdom" : {
+         "cities" : [
+            "London"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "GBP"
+         ],
+         "name" : "United Kingdom"
+      },
+      "United States" : {
+         "cities" : [
+            "Washington D.C."
+         ],
+         "continent" : "North America",
+         "currency" : [
+            "USD",
+            "USN",
+            "USS"
+         ],
+         "name" : "United States"
+      },
+      "Uruguay" : {
+         "cities" : [
+            "Montevideo"
+         ],
+         "continent" : "South America",
+         "currency" : [
+            "UYI",
+            "UYU"
+         ],
+         "name" : "Uruguay"
+      },
+      "Uzbekistan" : {
+         "cities" : [
+            "Tashkent"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "UZS"
+         ],
+         "name" : "Uzbekistan"
+      },
+      "Vanuatu" : {
+         "cities" : [
+            "Port Vila"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "VUV"
+         ],
+         "name" : "Vanuatu"
+      },
+      "Vatican City" : {
+         "cities" : [
+            "Vatican City"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Vatican City"
+      },
+      "Venezuela" : {
+         "cities" : [
+            "Caracas"
+         ],
+         "continent" : "South America",
+         "currency" : [
+            "VES"
+         ],
+         "name" : "Venezuela"
+      },
+      "Vietnam" : {
+         "cities" : [
+            "Hanoi"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "VND"
+         ],
+         "name" : "Vietnam"
+      },
+      "Wallis and Futuna" : {
+         "cities" : [
+            "Mata-Utu"
+         ],
+         "continent" : "Oceania",
+         "currency" : [
+            "XPF"
+         ],
+         "name" : "Wallis and Futuna"
+      },
+      "Western Sahara" : {
+         "cities" : [
+            "El Aaiún"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "MAD",
+            "DZD",
+            "MRU"
+         ],
+         "name" : "Western Sahara"
+      },
+      "Yemen" : {
+         "cities" : [
+            "Sana'a"
+         ],
+         "continent" : "Asia",
+         "currency" : [
+            "YER"
+         ],
+         "name" : "Yemen"
+      },
+      "Zambia" : {
+         "cities" : [
+            "Lusaka"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "ZMW"
+         ],
+         "name" : "Zambia"
+      },
+      "Zimbabwe" : {
+         "cities" : [
+            "Harare"
+         ],
+         "continent" : "Africa",
+         "currency" : [
+            "USD",
+            "ZAR",
+            "BWP",
+            "GBP",
+            "AUD",
+            "CNY",
+            "INR",
+            "JPY"
+         ],
+         "name" : "Zimbabwe"
+      },
+      "Åland" : {
+         "cities" : [
+            "Mariehamn"
+         ],
+         "continent" : "Europe",
+         "currency" : [
+            "EUR"
+         ],
+         "name" : "Åland"
+      }
+   },
+   "currencies" : {
+      "AED" : {
+         "country" : [
+            "United Arab Emirates"
+         ],
+         "name" : "AED"
+      },
+      "AFN" : {
+         "country" : [
+            "Afghanistan"
+         ],
+         "name" : "AFN"
+      },
+      "ALL" : {
+         "country" : [
+            "Albania"
+         ],
+         "name" : "ALL"
+      },
+      "AMD" : {
+         "country" : [
+            "Armenia"
+         ],
+         "name" : "AMD"
+      },
+      "ANG" : {
+         "country" : [
+            "Curacao",
+            "Sint Maarten"
+         ],
+         "name" : "ANG"
+      },
+      "AOA" : {
+         "country" : [
+            "Angola"
+         ],
+         "name" : "AOA"
+      },
+      "ARS" : {
+         "country" : [
+            "Argentina"
+         ],
+         "name" : "ARS"
+      },
+      "AUD" : {
+         "country" : [
+            "Zimbabwe",
+            "Australia",
+            "Christmas Island",
+            "Norfolk Island",
+            "Kiribati",
+            "Cocos [Keeling] Islands",
+            "Heard Island and McDonald Islands",
+            "Nauru",
+            "Tuvalu"
+         ],
+         "name" : "AUD"
+      },
+      "AWG" : {
+         "country" : [
+            "Aruba"
+         ],
+         "name" : "AWG"
+      },
+      "AZN" : {
+         "country" : [
+            "Azerbaijan"
+         ],
+         "name" : "AZN"
+      },
+      "BAM" : {
+         "country" : [
+            "Bosnia and Herzegovina"
+         ],
+         "name" : "BAM"
+      },
+      "BBD" : {
+         "country" : [
+            "Barbados"
+         ],
+         "name" : "BBD"
+      },
+      "BDT" : {
+         "country" : [
+            "Bangladesh"
+         ],
+         "name" : "BDT"
+      },
+      "BGN" : {
+         "country" : [
+            "Bulgaria"
+         ],
+         "name" : "BGN"
+      },
+      "BHD" : {
+         "country" : [
+            "Bahrain"
+         ],
+         "name" : "BHD"
+      },
+      "BIF" : {
+         "country" : [
+            "Burundi"
+         ],
+         "name" : "BIF"
+      },
+      "BMD" : {
+         "country" : [
+            "Bermuda"
+         ],
+         "name" : "BMD"
+      },
+      "BND" : {
+         "country" : [
+            "Brunei"
+         ],
+         "name" : "BND"
+      },
+      "BOB" : {
+         "country" : [
+            "Bolivia"
+         ],
+         "name" : "BOB"
+      },
+      "BOV" : {
+         "country" : [
+            "Bolivia"
+         ],
+         "name" : "BOV"
+      },
+      "BRL" : {
+         "country" : [
+            "Brazil"
+         ],
+         "name" : "BRL"
+      },
+      "BSD" : {
+         "country" : [
+            "Bahamas"
+         ],
+         "name" : "BSD"
+      },
+      "BTN" : {
+         "country" : [
+            "Bhutan"
+         ],
+         "name" : "BTN"
+      },
+      "BWP" : {
+         "country" : [
+            "Zimbabwe",
+            "Botswana"
+         ],
+         "name" : "BWP"
+      },
+      "BYN" : {
+         "country" : [
+            "Belarus"
+         ],
+         "name" : "BYN"
+      },
+      "BZD" : {
+         "country" : [
+            "Belize"
+         ],
+         "name" : "BZD"
+      },
+      "CAD" : {
+         "country" : [
+            "Canada"
+         ],
+         "name" : "CAD"
+      },
+      "CDF" : {
+         "country" : [
+            "Democratic Republic of the Congo"
+         ],
+         "name" : "CDF"
+      },
+      "CHE" : {
+         "country" : [
+            "Switzerland"
+         ],
+         "name" : "CHE"
+      },
+      "CHF" : {
+         "country" : [
+            "Switzerland",
+            "Liechtenstein"
+         ],
+         "name" : "CHF"
+      },
+      "CHW" : {
+         "country" : [
+            "Switzerland"
+         ],
+         "name" : "CHW"
+      },
+      "CLF" : {
+         "country" : [
+            "Chile"
+         ],
+         "name" : "CLF"
+      },
+      "CLP" : {
+         "country" : [
+            "Chile"
+         ],
+         "name" : "CLP"
+      },
+      "CNY" : {
+         "country" : [
+            "Zimbabwe",
+            "China"
+         ],
+         "name" : "CNY"
+      },
+      "COP" : {
+         "country" : [
+            "Colombia"
+         ],
+         "name" : "COP"
+      },
+      "CRC" : {
+         "country" : [
+            "Costa Rica"
+         ],
+         "name" : "CRC"
+      },
+      "CUC" : {
+         "country" : [
+            "Cuba"
+         ],
+         "name" : "CUC"
+      },
+      "CUP" : {
+         "country" : [
+            "Cuba"
+         ],
+         "name" : "CUP"
+      },
+      "CVE" : {
+         "country" : [
+            "Cape Verde"
+         ],
+         "name" : "CVE"
+      },
+      "CZK" : {
+         "country" : [
+            "Czech Republic"
+         ],
+         "name" : "CZK"
+      },
+      "DJF" : {
+         "country" : [
+            "Djibouti"
+         ],
+         "name" : "DJF"
+      },
+      "DKK" : {
+         "country" : [
+            "Faroe Islands",
+            "Greenland",
+            "Denmark"
+         ],
+         "name" : "DKK"
+      },
+      "DOP" : {
+         "country" : [
+            "Dominican Republic"
+         ],
+         "name" : "DOP"
+      },
+      "DZD" : {
+         "country" : [
+            "Algeria",
+            "Western Sahara"
+         ],
+         "name" : "DZD"
+      },
+      "EGP" : {
+         "country" : [
+            "Egypt"
+         ],
+         "name" : "EGP"
+      },
+      "ERN" : {
+         "country" : [
+            "Eritrea"
+         ],
+         "name" : "ERN"
+      },
+      "ETB" : {
+         "country" : [
+            "Ethiopia"
+         ],
+         "name" : "ETB"
+      },
+      "EUR" : {
+         "country" : [
+            "Cyprus",
+            "Åland",
+            "Estonia",
+            "Guadeloupe",
+            "Réunion",
+            "Slovenia",
+            "San Marino",
+            "Andorra",
+            "Saint Martin",
+            "Luxembourg",
+            "Ireland",
+            "Mayotte",
+            "Slovakia",
+            "French Southern Territories",
+            "Italy",
+            "Monaco",
+            "French Guiana",
+            "Kosovo",
+            "Saint Barthélemy",
+            "Saint Pierre and Miquelon",
+            "Finland",
+            "Martinique",
+            "Spain",
+            "Germany",
+            "Lithuania",
+            "Latvia",
+            "Portugal",
+            "France",
+            "Belgium",
+            "Montenegro",
+            "Vatican City",
+            "Austria",
+            "Malta",
+            "Greece",
+            "Netherlands"
+         ],
+         "name" : "EUR"
+      },
+      "FJD" : {
+         "country" : [
+            "Fiji"
+         ],
+         "name" : "FJD"
+      },
+      "FKP" : {
+         "country" : [
+            "Falkland Islands"
+         ],
+         "name" : "FKP"
+      },
+      "GBP" : {
+         "country" : [
+            "Zimbabwe",
+            "Guernsey",
+            "United Kingdom",
+            "South Georgia and the South Sandwich Islands",
+            "Isle of Man",
+            "Jersey"
+         ],
+         "name" : "GBP"
+      },
+      "GEL" : {
+         "country" : [
+            "Georgia"
+         ],
+         "name" : "GEL"
+      },
+      "GHS" : {
+         "country" : [
+            "Ghana"
+         ],
+         "name" : "GHS"
+      },
+      "GIP" : {
+         "country" : [
+            "Gibraltar"
+         ],
+         "name" : "GIP"
+      },
+      "GMD" : {
+         "country" : [
+            "Gambia"
+         ],
+         "name" : "GMD"
+      },
+      "GNF" : {
+         "country" : [
+            "Guinea"
+         ],
+         "name" : "GNF"
+      },
+      "GTQ" : {
+         "country" : [
+            "Guatemala"
+         ],
+         "name" : "GTQ"
+      },
+      "GYD" : {
+         "country" : [
+            "Guyana"
+         ],
+         "name" : "GYD"
+      },
+      "HKD" : {
+         "country" : [
+            "Hong Kong"
+         ],
+         "name" : "HKD"
+      },
+      "HNL" : {
+         "country" : [
+            "Honduras"
+         ],
+         "name" : "HNL"
+      },
+      "HRK" : {
+         "country" : [
+            "Croatia"
+         ],
+         "name" : "HRK"
+      },
+      "HTG" : {
+         "country" : [
+            "Haiti"
+         ],
+         "name" : "HTG"
+      },
+      "HUF" : {
+         "country" : [
+            "Hungary"
+         ],
+         "name" : "HUF"
+      },
+      "IDR" : {
+         "country" : [
+            "Indonesia"
+         ],
+         "name" : "IDR"
+      },
+      "ILS" : {
+         "country" : [
+            "Israel",
+            "Palestine"
+         ],
+         "name" : "ILS"
+      },
+      "INR" : {
+         "country" : [
+            "Zimbabwe",
+            "India",
+            "Bhutan"
+         ],
+         "name" : "INR"
+      },
+      "IQD" : {
+         "country" : [
+            "Iraq"
+         ],
+         "name" : "IQD"
+      },
+      "IRR" : {
+         "country" : [
+            "Iran"
+         ],
+         "name" : "IRR"
+      },
+      "ISK" : {
+         "country" : [
+            "Iceland"
+         ],
+         "name" : "ISK"
+      },
+      "JMD" : {
+         "country" : [
+            "Jamaica"
+         ],
+         "name" : "JMD"
+      },
+      "JOD" : {
+         "country" : [
+            "Jordan"
+         ],
+         "name" : "JOD"
+      },
+      "JPY" : {
+         "country" : [
+            "Zimbabwe",
+            "Japan"
+         ],
+         "name" : "JPY"
+      },
+      "KES" : {
+         "country" : [
+            "Kenya"
+         ],
+         "name" : "KES"
+      },
+      "KGS" : {
+         "country" : [
+            "Kyrgyzstan"
+         ],
+         "name" : "KGS"
+      },
+      "KHR" : {
+         "country" : [
+            "Cambodia"
+         ],
+         "name" : "KHR"
+      },
+      "KMF" : {
+         "country" : [
+            "Comoros"
+         ],
+         "name" : "KMF"
+      },
+      "KPW" : {
+         "country" : [
+            "North Korea"
+         ],
+         "name" : "KPW"
+      },
+      "KRW" : {
+         "country" : [
+            "South Korea"
+         ],
+         "name" : "KRW"
+      },
+      "KWD" : {
+         "country" : [
+            "Kuwait"
+         ],
+         "name" : "KWD"
+      },
+      "KYD" : {
+         "country" : [
+            "Cayman Islands"
+         ],
+         "name" : "KYD"
+      },
+      "KZT" : {
+         "country" : [
+            "Kazakhstan"
+         ],
+         "name" : "KZT"
+      },
+      "LAK" : {
+         "country" : [
+            "Laos"
+         ],
+         "name" : "LAK"
+      },
+      "LBP" : {
+         "country" : [
+            "Lebanon"
+         ],
+         "name" : "LBP"
+      },
+      "LKR" : {
+         "country" : [
+            "Sri Lanka"
+         ],
+         "name" : "LKR"
+      },
+      "LRD" : {
+         "country" : [
+            "Liberia"
+         ],
+         "name" : "LRD"
+      },
+      "LSL" : {
+         "country" : [
+            "Lesotho"
+         ],
+         "name" : "LSL"
+      },
+      "LYD" : {
+         "country" : [
+            "Libya"
+         ],
+         "name" : "LYD"
+      },
+      "MAD" : {
+         "country" : [
+            "Morocco",
+            "Western Sahara"
+         ],
+         "name" : "MAD"
+      },
+      "MDL" : {
+         "country" : [
+            "Moldova"
+         ],
+         "name" : "MDL"
+      },
+      "MGA" : {
+         "country" : [
+            "Madagascar"
+         ],
+         "name" : "MGA"
+      },
+      "MKD" : {
+         "country" : [
+            "North Macedonia"
+         ],
+         "name" : "MKD"
+      },
+      "MMK" : {
+         "country" : [
+            "Myanmar [Burma]"
+         ],
+         "name" : "MMK"
+      },
+      "MNT" : {
+         "country" : [
+            "Mongolia"
+         ],
+         "name" : "MNT"
+      },
+      "MOP" : {
+         "country" : [
+            "Macao"
+         ],
+         "name" : "MOP"
+      },
+      "MRU" : {
+         "country" : [
+            "Western Sahara",
+            "Mauritania"
+         ],
+         "name" : "MRU"
+      },
+      "MUR" : {
+         "country" : [
+            "Mauritius"
+         ],
+         "name" : "MUR"
+      },
+      "MVR" : {
+         "country" : [
+            "Maldives"
+         ],
+         "name" : "MVR"
+      },
+      "MWK" : {
+         "country" : [
+            "Malawi"
+         ],
+         "name" : "MWK"
+      },
+      "MXN" : {
+         "country" : [
+            "Mexico"
+         ],
+         "name" : "MXN"
+      },
+      "MYR" : {
+         "country" : [
+            "Malaysia"
+         ],
+         "name" : "MYR"
+      },
+      "MZN" : {
+         "country" : [
+            "Mozambique"
+         ],
+         "name" : "MZN"
+      },
+      "NAD" : {
+         "country" : [
+            "Namibia"
+         ],
+         "name" : "NAD"
+      },
+      "NGN" : {
+         "country" : [
+            "Nigeria"
+         ],
+         "name" : "NGN"
+      },
+      "NIO" : {
+         "country" : [
+            "Nicaragua"
+         ],
+         "name" : "NIO"
+      },
+      "NOK" : {
+         "country" : [
+            "Svalbard and Jan Mayen",
+            "Norway",
+            "Bouvet Island"
+         ],
+         "name" : "NOK"
+      },
+      "NPR" : {
+         "country" : [
+            "Nepal"
+         ],
+         "name" : "NPR"
+      },
+      "NZD" : {
+         "country" : [
+            "Niue",
+            "New Zealand",
+            "Pitcairn Islands",
+            "Cook Islands",
+            "Tokelau"
+         ],
+         "name" : "NZD"
+      },
+      "OMR" : {
+         "country" : [
+            "Oman"
+         ],
+         "name" : "OMR"
+      },
+      "PAB" : {
+         "country" : [
+            "Panama"
+         ],
+         "name" : "PAB"
+      },
+      "PEN" : {
+         "country" : [
+            "Peru"
+         ],
+         "name" : "PEN"
+      },
+      "PGK" : {
+         "country" : [
+            "Papua New Guinea"
+         ],
+         "name" : "PGK"
+      },
+      "PHP" : {
+         "country" : [
+            "Philippines"
+         ],
+         "name" : "PHP"
+      },
+      "PKR" : {
+         "country" : [
+            "Pakistan"
+         ],
+         "name" : "PKR"
+      },
+      "PLN" : {
+         "country" : [
+            "Poland"
+         ],
+         "name" : "PLN"
+      },
+      "PYG" : {
+         "country" : [
+            "Paraguay"
+         ],
+         "name" : "PYG"
+      },
+      "QAR" : {
+         "country" : [
+            "Qatar"
+         ],
+         "name" : "QAR"
+      },
+      "RON" : {
+         "country" : [
+            "Romania"
+         ],
+         "name" : "RON"
+      },
+      "RSD" : {
+         "country" : [
+            "Serbia"
+         ],
+         "name" : "RSD"
+      },
+      "RUB" : {
+         "country" : [
+            "Russia"
+         ],
+         "name" : "RUB"
+      },
+      "RWF" : {
+         "country" : [
+            "Rwanda"
+         ],
+         "name" : "RWF"
+      },
+      "SAR" : {
+         "country" : [
+            "Saudi Arabia"
+         ],
+         "name" : "SAR"
+      },
+      "SBD" : {
+         "country" : [
+            "Solomon Islands"
+         ],
+         "name" : "SBD"
+      },
+      "SCR" : {
+         "country" : [
+            "Seychelles"
+         ],
+         "name" : "SCR"
+      },
+      "SDG" : {
+         "country" : [
+            "Sudan"
+         ],
+         "name" : "SDG"
+      },
+      "SEK" : {
+         "country" : [
+            "Sweden"
+         ],
+         "name" : "SEK"
+      },
+      "SGD" : {
+         "country" : [
+            "Singapore"
+         ],
+         "name" : "SGD"
+      },
+      "SHP" : {
+         "country" : [
+            "Saint Helena"
+         ],
+         "name" : "SHP"
+      },
+      "SLL" : {
+         "country" : [
+            "Sierra Leone"
+         ],
+         "name" : "SLL"
+      },
+      "SOS" : {
+         "country" : [
+            "Somalia"
+         ],
+         "name" : "SOS"
+      },
+      "SRD" : {
+         "country" : [
+            "Suriname"
+         ],
+         "name" : "SRD"
+      },
+      "SSP" : {
+         "country" : [
+            "South Sudan"
+         ],
+         "name" : "SSP"
+      },
+      "STN" : {
+         "country" : [
+            "São Tomé and Príncipe"
+         ],
+         "name" : "STN"
+      },
+      "SVC" : {
+         "country" : [
+            "El Salvador"
+         ],
+         "name" : "SVC"
+      },
+      "SYP" : {
+         "country" : [
+            "Syria"
+         ],
+         "name" : "SYP"
+      },
+      "SZL" : {
+         "country" : [
+            "Swaziland"
+         ],
+         "name" : "SZL"
+      },
+      "THB" : {
+         "country" : [
+            "Thailand"
+         ],
+         "name" : "THB"
+      },
+      "TJS" : {
+         "country" : [
+            "Tajikistan"
+         ],
+         "name" : "TJS"
+      },
+      "TMT" : {
+         "country" : [
+            "Turkmenistan"
+         ],
+         "name" : "TMT"
+      },
+      "TND" : {
+         "country" : [
+            "Tunisia"
+         ],
+         "name" : "TND"
+      },
+      "TOP" : {
+         "country" : [
+            "Tonga"
+         ],
+         "name" : "TOP"
+      },
+      "TRY" : {
+         "country" : [
+            "Turkey"
+         ],
+         "name" : "TRY"
+      },
+      "TTD" : {
+         "country" : [
+            "Trinidad and Tobago"
+         ],
+         "name" : "TTD"
+      },
+      "TWD" : {
+         "country" : [
+            "Taiwan"
+         ],
+         "name" : "TWD"
+      },
+      "TZS" : {
+         "country" : [
+            "Tanzania"
+         ],
+         "name" : "TZS"
+      },
+      "UAH" : {
+         "country" : [
+            "Ukraine"
+         ],
+         "name" : "UAH"
+      },
+      "UGX" : {
+         "country" : [
+            "Uganda"
+         ],
+         "name" : "UGX"
+      },
+      "USD" : {
+         "country" : [
+            "El Salvador",
+            "Marshall Islands",
+            "Zimbabwe",
+            "Northern Mariana Islands",
+            "Guam",
+            "United States",
+            "Haiti",
+            "British Virgin Islands",
+            "Turks and Caicos Islands",
+            "American Samoa",
+            "East Timor",
+            "Puerto Rico",
+            "Micronesia",
+            "Palau",
+            "U.S. Virgin Islands",
+            "Bonaire",
+            "Ecuador",
+            "British Indian Ocean Territory",
+            "U.S. Minor Outlying Islands",
+            "Panama"
+         ],
+         "name" : "USD"
+      },
+      "USN" : {
+         "country" : [
+            "United States"
+         ],
+         "name" : "USN"
+      },
+      "USS" : {
+         "country" : [
+            "United States"
+         ],
+         "name" : "USS"
+      },
+      "UYI" : {
+         "country" : [
+            "Uruguay"
+         ],
+         "name" : "UYI"
+      },
+      "UYU" : {
+         "country" : [
+            "Uruguay"
+         ],
+         "name" : "UYU"
+      },
+      "UZS" : {
+         "country" : [
+            "Uzbekistan"
+         ],
+         "name" : "UZS"
+      },
+      "VES" : {
+         "country" : [
+            "Venezuela"
+         ],
+         "name" : "VES"
+      },
+      "VND" : {
+         "country" : [
+            "Vietnam"
+         ],
+         "name" : "VND"
+      },
+      "VUV" : {
+         "country" : [
+            "Vanuatu"
+         ],
+         "name" : "VUV"
+      },
+      "WST" : {
+         "country" : [
+            "Samoa"
+         ],
+         "name" : "WST"
+      },
+      "XAF" : {
+         "country" : [
+            "Chad",
+            "Republic of the Congo",
+            "Central African Republic",
+            "Equatorial Guinea",
+            "Gabon",
+            "Cameroon"
+         ],
+         "name" : "XAF"
+      },
+      "XCD" : {
+         "country" : [
+            "Grenada",
+            "Saint Vincent and the Grenadines",
+            "Antigua and Barbuda",
+            "Saint Lucia",
+            "Saint Kitts and Nevis",
+            "Montserrat",
+            "Dominica",
+            "Anguilla"
+         ],
+         "name" : "XCD"
+      },
+      "XOF" : {
+         "country" : [
+            "Togo",
+            "Senegal",
+            "Burkina Faso",
+            "Mali",
+            "Niger",
+            "Guinea-Bissau",
+            "Benin",
+            "Ivory Coast"
+         ],
+         "name" : "XOF"
+      },
+      "XPF" : {
+         "country" : [
+            "New Caledonia",
+            "French Polynesia",
+            "Wallis and Futuna"
+         ],
+         "name" : "XPF"
+      },
+      "YER" : {
+         "country" : [
+            "Yemen"
+         ],
+         "name" : "YER"
+      },
+      "ZAR" : {
+         "country" : [
+            "Zimbabwe",
+            "Lesotho",
+            "South Africa",
+            "Namibia"
+         ],
+         "name" : "ZAR"
+      },
+      "ZMW" : {
+         "country" : [
+            "Zambia"
+         ],
+         "name" : "ZMW"
+      }
+   }
+}

--- a/examples/context_sensitive_completion/data/munge_country_data.pl
+++ b/examples/context_sensitive_completion/data/munge_country_data.pl
@@ -1,0 +1,84 @@
+#!/usr/bin/perl
+
+use 5.020;
+use warnings;
+
+use FindBin;
+use File::Slurp;
+use JSON::MaybeXS;
+
+# Data sources: https://github.com/annexare/Countries/tree/master/data
+# https://raw.githubusercontent.com/annexare/Countries/master/data/continents.json
+# https://raw.githubusercontent.com/annexare/Countries/master/data/countries.json
+
+my $continent_data = load_json('continents.json');
+my $country_data   = load_json('countries.json');
+my $description    = {
+    generated_by => $FindBin::Script,
+    sources      => {
+        '_repository' => 'https://github.com/annexare/Countries',
+        'continents.json' => 'master/data/continents.json',
+        'countries.json' => 'master/data/countries.json',
+    },
+};
+
+my %continent;
+my %country;
+my %currency;
+my %city;
+
+for my $country_record (values %$country_data) {
+    my ($country_name, $continent_code, $capital_name, $currencies) =
+        @{$country_record}{qw( name continent capital currency )};
+
+    my $continent_name = $continent_data->{$continent_code};
+
+    my $continent_record = $continent{$continent_name} //= {
+        name => $continent_name,
+        countries => [],
+    };
+
+    push @{$continent_record->{countries}}, $country_name;
+
+    $capital_name ||= $country_name;
+
+    $country{$country_name} = {
+        name => $country_name,
+        continent => $continent_name,
+        cities => [ $capital_name ],
+        currency => $currencies,
+    };
+
+    for my $currency ( @{$currencies} ) {
+        my $curr_record = $currency{$currency} //= {
+            name => $currency,
+            country => [],
+        };
+        push @{$curr_record->{country}}, $country_name;
+    }
+
+    my $city_record = $city{$capital_name} //= {
+        name => $capital_name,
+        countries => [],
+    };
+    push @{$city_record->{countries}}, $country_name;
+    
+}
+
+my $data = {
+    _description => $description,
+    continents   => \%continent,
+    countries    => \%country,
+    cities       => \%city,
+    currencies   => \%currency,
+};
+
+print JSON::MaybeXS->new(utf8 => 1, pretty => 1, canonical => 1)->encode($data);
+
+sub load_json {
+    my ($fname) = @_;
+    my $text = read_file($fname);
+
+    state $js_obj = JSON::MaybeXS->new(utf8 => 1);
+    return $js_obj->decode($text);
+}

--- a/examples/getopt_test.pl
+++ b/examples/getopt_test.pl
@@ -1,0 +1,30 @@
+#!/usr/bin/env perl
+#
+# Demo script to show the difference between
+# calling get_options_from_array with "pass_through"
+# enabled and disabled.
+#
+# Usage:
+#
+#   getopt_test.pl FLAG ARG ...
+#
+use 5.014;
+use warnings;
+use Data::Dumper;
+use Term::CLI::Util qw( get_options_from_array );
+
+my ($pass_through, @args) = @ARGV;
+
+my %options;
+
+my %result = get_options_from_array(
+   args         => \@args,
+   spec         => [ 'verbose|v+', 'debug|d' ],
+   result       => \%options,
+   pass_through => $pass_through,
+);
+
+print Data::Dumper->Dump(
+   [ \%result, \%options, \@args ],
+   [ '*result', '*options', '*args' ]
+);

--- a/lib/Term/CLI.pm
+++ b/lib/Term/CLI.pm
@@ -7,7 +7,7 @@
 #       Author:  Steven Bakker (SBAKKER), <sbakker@cpan.org>
 #      Created:  31/01/18
 #
-#   Copyright (c) 2018 Steven Bakker
+#   Copyright (c) 2018-2022 Steven Bakker
 #
 #   This module is free software; you can redistribute it and/or modify
 #   it under the same terms as Perl itself. See "perldoc perlartistic."

--- a/lib/Term/CLI.pm
+++ b/lib/Term/CLI.pm
@@ -105,13 +105,18 @@ has quote_characters => ( is => 'rw', isa => Str, default => sub {q("')} );
 sub BUILD {
     my ( $self, $args ) = @_;
 
-    my $term = Term::CLI::ReadLine->new( $self->name )->term;
+    my @fh_list = ( \*STDIN, \*STDOUT );
+    if (exists $args->{filehandles}) {
+        @fh_list = @{ $args->{filehandles} // [] };
+    }
+
+    my $term = Term::CLI::ReadLine->new( $self->name, @fh_list );
 
     if ( my $sig_list = $args->{ignore_keyboard_signals} ) {
         $term->ignore_keyboard_signals( @{$sig_list} );
     }
 
-    $term->Attribs->{char_is_quoted_p}    = sub { $self->_is_escaped(@_) };
+    $term->Attribs->{char_is_quoted_p} = sub { $self->_is_escaped(@_) };
 
     $self->_set_completion_attribs;
 
@@ -306,6 +311,26 @@ and L<Term::CLI::Intro>(3p) first, and peruse the example
 scripts in the source distribution's F<examples> and
 F<tutorial> directories.
 
+=head2 I/O handles
+
+By default C<Term::CLI> will create a
+L<Term::CLI::ReadLine|Term::CLI::ReadLine> object
+(which creates a L<Term::ReadLine|Term::ReadLine> object)
+that reads from F<STDIN> and writes to F<STDOUT>.
+
+This is notably different from the default behaviour of e.g.
+GNU Readline which opens the TTY separately. This may cause
+unexpected behaviour in case of UTF-8 I/O.
+
+By explicitly specifying F<STDIN> and F<STDOUT> as the I/O
+handles, we force the underlying readline implementation to
+use the same I/O encoding as the standard I/O handles. This
+means that e.g. C<use open qw(:std :utf8)> will do what you
+expect and enable UTF-8 input/output.
+
+See the C<filehandles> argument to L<new|/new> below for information
+on how to change this.
+
 =head1 CLASS STRUCTURE
 
 =head2 Inherits from:
@@ -333,6 +358,18 @@ Valid attributes:
 
 Reference to a subroutine that should be called when the command
 is executed, or C<undef>.
+
+=item B<filehandles> =E<gt> I<ArrayRef>
+
+File handles to use for input and output, resp. The array can be:
+
+    undef
+    [ ]
+    [ IN_FH, OUT_FH ]
+
+If the value is either C<undef> or an empty list, then we rely
+on the underlying readline's implementation to determine the
+I/O handles (but see L<I/O handles|I/O handles> above).
 
 =item B<cleanup> =E<gt> I<CodeRef>
 

--- a/lib/Term/CLI/Argument.pm
+++ b/lib/Term/CLI/Argument.pm
@@ -7,7 +7,7 @@
 #       Author:  Steven Bakker (SBAKKER), <sbakker@cpan.org>
 #      Created:  22/01/18
 #
-#   Copyright (c) 2018 Steven Bakker
+#   Copyright (c) 2018-2022 Steven Bakker
 #
 #   This module is free software; you can redistribute it and/or modify
 #   it under the same terms as Perl itself. See "perldoc perlartistic."

--- a/lib/Term/CLI/Argument.pm
+++ b/lib/Term/CLI/Argument.pm
@@ -73,7 +73,7 @@ before validate => sub {
 };
 
 sub validate {
-    my ( $self, $value ) = @_;
+    my ( $self, $value, $state ) = @_;
 
     if ( not defined $value or $value eq q{} ) {
         return $self->set_error( loc('value cannot be empty') );
@@ -189,17 +189,54 @@ Return the argument "type". By default, this is the object's class name
 with the C<M6::CLI::Argument::> prefix removed. Can be overloaded to
 provide a different value.
 
-=item B<validate> ( I<value> )
+=item B<validate> ( I<TEXT>, I<STATE> )
 
-Check whether I<value> is a valid value for this object. Return the
-(possibly normalised) value if it is, nothing (i.e. C<undef> or the
-empty list, depending on call context) if it is not (and set the
+Check whether I<TEXT> is a valid value for this object. Return the
+(possibly normalised) value if it is valid. Otherwise, return nothing
+(i.e. C<undef> or the empty list, depending on call context) and set the
 L<error|/error>() attribute).
 
 By default, this method only checks whether I<value> is defined and not
 an empty string.
 
 Sub-classes should probably override this.
+
+The C<validate> function can be made context-aware by inspecting the
+I<STATE> parameter, a HashRef containing the same key/value pairs
+as in the arguments to the
+L<command callback|Term::CLI::Role::CommandSet|/callback>
+function (see also
+L<Term::CLI::Role::CommandSet|Term::CLI::Role::CommandSet>):
+
+    STATE = {
+        status       => Int,
+        error        => Str,
+        options      => HashRef,
+        arguments    => ArrayRef[Value],
+        command_line => Str,
+        command_path => ArrayRef[InstanceOf['Term::CLI::Command']],
+    }
+
+The C<arguments> array holds the argument values (scalars) that were parsed up
+until now (not including the current argument value).
+
+The C<command_path> array holds the L<Term::CLI::Command|Term::CLI::Command>
+objects that were parsed up until now. This means that the command to which
+this argument applies can be accessed with:
+
+    CURRENT_COMMAND = STATE->{command_path}->[-1];
+
+The C<command_line> is the full string as it was passed from
+L<readline|Term::CLI/readline>.
+
+=over 6
+
+=item B<NOTE:>
+
+Care should be taken to not modify the values in the I<STATE> HashRef.
+Modifications may result in unexpected behaviour.
+
+=back
 
 =back
 

--- a/lib/Term/CLI/Argument/Bool.pm
+++ b/lib/Term/CLI/Argument/Bool.pm
@@ -114,7 +114,7 @@ sub complete {
         }
         return ( sort map { $value . substr $_, length $value } @matches );
     }
-    return ( sort grep { is_prefix_str( lc $value, lc $_ ) } @values );
+    return ( sort grep { is_prefix_str( $value, $_ ) } @values );
 }
 
 1;

--- a/lib/Term/CLI/Argument/Bool.pm
+++ b/lib/Term/CLI/Argument/Bool.pm
@@ -30,6 +30,7 @@ use Types::Standard 1.000005 qw(
 );
 
 use Term::CLI::L10N qw( loc );
+use Term::CLI::Util qw( is_prefix_str );
 
 use Moo 1.000001;
 use namespace::clean 0.25;
@@ -73,8 +74,8 @@ sub validate {
         $false = $self->false_values;
     }
 
-    my @true_match  = grep { rindex( $_, $value, 0 ) == 0 } @{$true};
-    my @false_match = grep { rindex( $_, $value, 0 ) == 0 } @{$false};
+    my @true_match  = grep { is_prefix_str( $value, $_ ) } @{$true};
+    my @false_match = grep { is_prefix_str( $value, $_ ) } @{$false};
 
     if (@true_match) {
         if (@false_match) {
@@ -102,12 +103,18 @@ sub complete {
     return ( sort @values ) if $value eq q{};
 
     if ( $self->ignore_case ) {
-        my @matches =
-            grep { substr( lc $_, 0, length $value ) eq lc $value } @values;
+        my @matches = grep { is_prefix_str( lc $value, lc $_ ) } @values;
 
+        # Cannot just return @matches because of potential case differences.
+        if ( $value =~ m{ \p{Lu}\z }xsm ) {
+            return ( sort map { $value . uc substr $_, length $value } @matches );
+        }
+        if ( $value =~ m{ \p{Ll}\z }xsm ) {
+            return ( sort map { $value . lc substr $_, length $value } @matches );
+        }
         return ( sort map { $value . substr $_, length $value } @matches );
     }
-    return ( sort grep { substr( $_, 0, length $value ) eq $value } @values );
+    return ( sort grep { is_prefix_str( lc $value, lc $_ ) } @values );
 }
 
 1;

--- a/lib/Term/CLI/Argument/Bool.pm
+++ b/lib/Term/CLI/Argument/Bool.pm
@@ -7,7 +7,7 @@
 #       Author:  Steven Bakker (SBAKKER), <sbakker@cpan.org>
 #      Created:  22/01/18
 #
-#   Copyright (c) 2018 Steven Bakker
+#   Copyright (c) 2018-2022 Steven Bakker
 #
 #   This module is free software; you can redistribute it and/or modify
 #   it under the same terms as Perl itself. See "perldoc perlartistic."

--- a/lib/Term/CLI/Argument/Enum.pm
+++ b/lib/Term/CLI/Argument/Enum.pm
@@ -7,7 +7,7 @@
 #       Author:  Steven Bakker (SBAKKER), <sbakker@cpan.org>
 #      Created:  22/Jan/2018
 #
-#   Copyright (c) 2018 Steven Bakker
+#   Copyright (c) 2018-2022 Steven Bakker
 #
 #   This module is free software; you can redistribute it and/or modify
 #   it under the same terms as Perl itself. See "perldoc perlartistic."

--- a/lib/Term/CLI/Argument/Filename.pm
+++ b/lib/Term/CLI/Argument/Filename.pm
@@ -33,8 +33,7 @@ use Fcntl ':mode';
 use namespace::clean;
 
 sub complete {
-    my $self    = shift;
-    my $partial = shift;
+    my ( $self, $partial ) = @_;
 
     my $func_ref = $self->term->Attribs->{filename_completion_function}
         or return $self->_glob_complete($partial);

--- a/lib/Term/CLI/Argument/Filename.pm
+++ b/lib/Term/CLI/Argument/Filename.pm
@@ -7,7 +7,7 @@
 #       Author:  Steven Bakker (SBAKKER), <sbakker@cpan.org>
 #      Created:  23/01/18
 #
-#   Copyright (c) 2018 Steven Bakker
+#   Copyright (c) 2022 Steven Bakker
 #
 #   This module is free software; you can redistribute it and/or modify
 #   it under the same terms as Perl itself. See "perldoc perlartistic."
@@ -33,15 +33,15 @@ use Fcntl ':mode';
 use namespace::clean;
 
 sub complete {
-    my ( $self, $partial ) = @_;
+    my ( $self, $text ) = @_;
 
     my $func_ref = $self->term->Attribs->{filename_completion_function}
-        or return $self->_glob_complete($partial);
+        or return $self->_glob_complete($text);
 
     if ($func_ref) {
         my $state = 0;
         my @list;
-        while ( my $f = $func_ref->( $partial, $state ) ) {
+        while ( my $f = $func_ref->( $text, $state ) ) {
             push @list, $f;
             $state = 1;
         }
@@ -50,8 +50,8 @@ sub complete {
 }
 
 sub _glob_complete {
-    my ( $self, $partial ) = @_;
-    my @list = bsd_glob("$partial*");
+    my ( $self, $text ) = @_;
+    my @list = bsd_glob("$text*");
 
     return if @list == 0;
 
@@ -59,14 +59,13 @@ sub _glob_complete {
         if (-d $list[0]) {
             # Dumb trick to get readline to expand a directory
             # with a trailing "/", but *not* add a space.
-            # Simulates the Gnu way of doing it.
+            # Simulates the way GNU readline does it.
             return ("$list[0]/", "$list[0]//");
         }
         return @list;
     }
 
-    # If there is more than one possible completion,
-    # add filetype suffixes.
+    # Add filetype suffixes if there is more than one possible completion.
     foreach (@list) {
         lstat;
         if ( -l _ )  { $_ .= q{@}; next }
@@ -125,14 +124,19 @@ See L<Term::CLI::Argument>(3p). Additionally:
 
 =over
 
-=item B<complete> ( I<PARTIAL> )
+=item B<complete> ( I<TEXT> )
 
-If present, use the C<filename_completion_function> function listed
-in L<Term::ReadLine>'s C<Attribs>, otherwise use L<bsd_glob from
-File::Glob|File::Glob/bsd_glob>.
+=item B<complete> ( I<TEXT>, I<STATE> )
+
+Complete the (partial) filename in I<TEXT>. The I<STATE> HashRef is
+ignored.
+
+If present, this uses the C<filename_completion_function> function listed
+in L<Term::ReadLine>'s C<Attribs>, otherwise it will use its own
+implementation based on L<bsd_glob from File::Glob|File::Glob/bsd_glob>.
 
 Not every C<Term::ReadLine> implementation implements its own
-filename completion function. The ones that do will ave the
+filename completion function. The ones that do will have the
 C<Attrib-E<gt>{filename_completion_function}> attribute set.
 L<Term::ReadLine::Gnu> does this, while L<Term::ReadLine::Perl> doesn't.
 
@@ -147,11 +151,11 @@ L<Term::CLI>(3p).
 
 =head1 AUTHOR
 
-Steven Bakker E<lt>sbakker@cpan.orgE<gt>, 2018.
+Steven Bakker E<lt>sbakker@cpan.orgE<gt>, 2022.
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (c) 2018 Steven Bakker
+Copyright (c) 2022 Steven Bakker
 
 This module is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself. See "perldoc perlartistic."

--- a/lib/Term/CLI/Argument/Number.pm
+++ b/lib/Term/CLI/Argument/Number.pm
@@ -7,7 +7,7 @@
 #       Author:  Steven Bakker (SBAKKER), <sbakker@cpan.org>
 #      Created:  22/01/18
 #
-#   Copyright (c) 2018 Steven Bakker
+#   Copyright (c) 2018-2022 Steven Bakker
 #
 #   This module is free software; you can redistribute it and/or modify
 #   it under the same terms as Perl itself. See "perldoc perlartistic."

--- a/lib/Term/CLI/Argument/Number/Float.pm
+++ b/lib/Term/CLI/Argument/Number/Float.pm
@@ -7,7 +7,7 @@
 #       Author:  Steven Bakker (SBAKKER), <sbakker@cpan.org>
 #      Created:  22/01/18
 #
-#   Copyright (c) 2018 Steven Bakker
+#   Copyright (c) 2018-2022 Steven Bakker
 #
 #   This module is free software; you can redistribute it and/or modify
 #   it under the same terms as Perl itself. See "perldoc perlartistic."

--- a/lib/Term/CLI/Argument/Number/Int.pm
+++ b/lib/Term/CLI/Argument/Number/Int.pm
@@ -7,7 +7,7 @@
 #       Author:  Steven Bakker (SBAKKER), <sbakker@cpan.org>
 #      Created:  22/01/18
 #
-#   Copyright (c) 2018 Steven Bakker
+#   Copyright (c) 2018-2022 Steven Bakker
 #
 #   This module is free software; you can redistribute it and/or modify
 #   it under the same terms as Perl itself. See "perldoc perlartistic."

--- a/lib/Term/CLI/Argument/String.pm
+++ b/lib/Term/CLI/Argument/String.pm
@@ -7,7 +7,7 @@
 #       Author:  Steven Bakker (SBAKKER), <sbakker@cpan.org>
 #      Created:  22/01/18
 #
-#   Copyright (c) 2018 Steven Bakker
+#   Copyright (c) 2018-2022 Steven Bakker
 #
 #   This module is free software; you can redistribute it and/or modify
 #   it under the same terms as Perl itself. See "perldoc perlartistic."

--- a/lib/Term/CLI/Base.pm
+++ b/lib/Term/CLI/Base.pm
@@ -7,7 +7,7 @@
 #       Author:  Steven Bakker (SBAKKER), <sbakker@cpan.org>
 #      Created:  10/02/18
 #
-#   Copyright (c) 2018 Steven Bakker
+#   Copyright (c) 2018-2022 Steven Bakker
 #
 #   This module is free software; you can redistribute it and/or modify
 #   it under the same terms as Perl itself. See "perldoc perlartistic."

--- a/lib/Term/CLI/Command.pm
+++ b/lib/Term/CLI/Command.pm
@@ -7,7 +7,7 @@
 #       Author:  Steven Bakker (SBAKKER), <sbakker@cpan.org>
 #      Created:  30/01/18
 #
-#   Copyright (c) 2018 Steven Bakker
+#   Copyright (c) 2018-2022 Steven Bakker
 #
 #   This module is free software; you can redistribute it and/or modify
 #   it under the same terms as Perl itself. See "perldoc perlartistic."

--- a/lib/Term/CLI/Command.pm
+++ b/lib/Term/CLI/Command.pm
@@ -579,7 +579,7 @@ function
 (see L<Term::CLI::Role::CommandSet|Term::CLI::Role::CommandSet>),
 and returns the same structure.
 
-The C<arguments> parametr (an I<ArrayRef>) should contain the words
+The C<arguments> parameter (an I<ArrayRef>) should contain the words
 on the command line that have not been parsed yet.
 
 Depending on whether the object has sub-commands or arguments, the rest of

--- a/lib/Term/CLI/Command.pm
+++ b/lib/Term/CLI/Command.pm
@@ -218,15 +218,13 @@ sub _check_arguments {
         for my $i ( 1 .. $args_to_check ) {
             my $arg = $unparsed->[0];
             $argno++;
-            my $arg_value = $arg_spec->validate($arg);
+            my $arg_value = $arg_spec->validate($arg, \%args);
             if ( !defined $arg_value ) {
                 return (
                     %args,
                     status => -1,
-                    error  => "arg#$argno, '$arg': "
+                    error  => "arg#$argno (" . $arg_spec->name . "), '$arg': "
                         . $arg_spec->error . q{ }
-                        . loc("for") . q{ '}
-                        . $arg_spec->name . q{'}
                 );
             }
             push @{ $args{arguments} }, $arg_value;

--- a/lib/Term/CLI/Command.pm
+++ b/lib/Term/CLI/Command.pm
@@ -1,4 +1,5 @@
-#============================================================================= #
+#=============================================================================
+#
 #       Module:  Term::CLI::Command
 #
 #  Description:  Class for (sub-)commands in Term::CLI
@@ -23,7 +24,6 @@ use 5.014;
 use warnings;
 
 use List::Util 1.23 qw( first min );
-use Getopt::Long 2.38 qw( GetOptionsFromArray );
 use Types::Standard 1.000005 qw(
     ArrayRef
     CodeRef
@@ -33,6 +33,7 @@ use Types::Standard 1.000005 qw(
 );
 
 use Term::CLI::L10N qw( loc );
+use Term::CLI::Util qw( get_options_from_array );
 
 use Moo 1.000001;
 use namespace::clean 0.25;
@@ -62,71 +63,57 @@ sub option_names {
 }
 
 sub complete {
-    my ( $self, @words ) = @_;
+    my ( $self, $text, $state ) = @_;
 
-    my $partial = $words[-1] // q{};
+    $text  //= q{};
+    $state //= {};
+
+    my $processed       = $state->{processed}     //= [];
+    my $unprocessed     = $state->{unprocessed}   //= [];
+    my $parsed_options  = $state->{options}       //= {};
 
     if ( $self->has_options ) {
 
-        Getopt::Long::Configure(qw(bundling require_order pass_through));
+        my %opt_result = get_options_from_array(
+            args         => $unprocessed,
+            spec         => $self->options,
+            result       => $parsed_options,
+            pass_through => 1,
+        );
 
-        my $opt_specs = $self->options;
+        my $double_dash = $opt_result{double_dash};
 
-        my %parsed_opts;
-
-        my $has_terminator;
-        if ( $Getopt::Long::VERSION < 2.51 ) {
-
-            # Getopt::Long before 2.51 removes '--' from word list;
-            # Try to work around the bug. Can still be fooled by
-            # "--foo --" if "--foo" takes an argument. :-/
-            $has_terminator = first { $_ eq '--' } @words[ 0 .. $#words - 1 ];
-            ## no critic (RequireCheckingReturnValueOfEval)
-            eval {
-                GetOptionsFromArray( \@words, \%parsed_opts, @{$opt_specs} );
-            };
-        }
-        else {
-            ## no critic (RequireCheckingReturnValueOfEval)
-            eval {
-                GetOptionsFromArray( \@words, \%parsed_opts, @{$opt_specs} );
-            };
-            if ( @words > 1 && $words[0] eq '--' ) {
-                $has_terminator = shift @words;
-            }
-        }
-        if ( !$has_terminator && @words <= 1 && $partial =~ /^-/x ) {
-
-            # We have to complete a command-line option.
-            return grep { rindex( $_, $partial, 0 ) == 0 } $self->option_names;
+        # Check if we have to complete a command-line option.
+        if ( !$double_dash && @{$unprocessed} == 0 && $text =~ /^-/x ) {
+            return grep { rindex( $_, $text, 0 ) == 0 } $self->option_names;
         }
     }
 
     # If the command has arguments, try to skip over them.
     if ( $self->has_arguments ) {
         my @args = $self->arguments;
-        my $n    = 0;
-        while ( @words > 1 ) {
-            last if @args == 0;
-            shift @words;
-            $n++;
-            if ( $args[0]->max_occur > 0 and $n >= $args[0]->max_occur ) {
+        my $arg_repeat = 0;
+        while ( @{$unprocessed} && @args ) {
+            push @{$processed}, shift @{$unprocessed};
+            $arg_repeat++;
+            if ( $args[0]->max_occur > 0 and $arg_repeat >= $args[0]->max_occur ) {
                 shift @args;
-                $n = 0;
+                $arg_repeat = 0;
             }
         }
 
         if (@args) {
-            return $args[0]->complete( $words[0] );
+            return $args[0]->complete( $text, $state );
         }
     }
 
     if ( $self->has_commands ) {
-        if ( @words <= 1 ) {
-            return grep { rindex( $_, $partial, 0 ) == 0 } $self->command_names;
+        if ( @{$unprocessed} == 0 ) {
+            return grep { rindex( $_, $text, 0 ) == 0 } $self->command_names;
         }
-        if ( my $cmd = $self->find_command( $words[0] ) ) {
-            return $cmd->complete( @words[ 1 .. $#words ] );
+        if ( my $cmd = $self->find_command( $unprocessed->[0] ) ) {
+            push @{$processed}, shift @{$unprocessed};
+            return $cmd->complete( $text, $state );
         }
     }
 
@@ -149,20 +136,16 @@ sub execute_command {
     push @{ $args{command_path} }, $self;
 
     if ( $self->has_options ) {
-        my $opt_specs = $self->options;
+        my %opt_result = get_options_from_array(
+            args         => $args{unparsed},
+            spec         => $self->options,
+            result       => $args{options},
+            pass_through => 0,
+        );
 
-        Getopt::Long::Configure(qw(bundling require_order no_pass_through));
-
-        my $error = q{};
-        my $ok    = do {
-            local ( $SIG{__WARN__} ) =
-                sub { chomp( $error = join( q{}, @_ ) ) };
-            GetOptionsFromArray( $args{unparsed}, $args{options}, @$opt_specs );
-        };
-
-        if ( !$ok ) {
+        if ( !$opt_result{success} ) {
             $args{status} = -1;
-            $args{error}  = $error;
+            $args{error}  = $opt_result{error_msg};
             return $self->try_callback(%args);
         }
     }
@@ -346,19 +329,19 @@ Term::CLI::Command - Class for (sub-)commands in Term::CLI
 
 =head1 DESCRIPTION
 
-Class for command elements in L<Term::CLI>(3p).
+Class for command elements in L<Term::CLI|Term::CLI>(3p).
 
 =head1 CLASS STRUCTURE
 
 =head2 Inherits from:
 
-L<Term::CLI::Element>(3p).
+L<Term::CLI::Element|Term::CLI::Element>(3p).
 
 =head2 Consumes:
 
-L<Term::CLI::Role::ArgumentSet>(3p),
-L<Term::CLI::Role::CommandSet>(3p),
-L<Term::CLI::Role::HelpText>(3p).
+L<Term::CLI::Role::ArgumentSet|Term::CLI::Role::ArgumentSet>(3p),
+L<Term::CLI::Role::CommandSet|Term::CLI::Role::CommandSet>(3p),
+L<Term::CLI::Role::HelpText|Term::CLI::Role::HelpText>(3p).
 
 =head1 CONSTRUCTORS
 
@@ -378,11 +361,13 @@ Other attributes are:
 
 =item B<arguments> =E<gt> I<ArrayRef>
 
-Reference to an array containing L<Term::CLI::Argument>(3p) object
+Reference to an array containing
+L<Term::CLI::Argument|Term::CLI::Argument>(3p) object
 instances that describe the parameters that the command takes,
 or C<undef>.
 
-See also L<Term::CLI::Role::ArgumentSet|Term::CLI::Role::ArgumentSet/ATTRIBUTES>.
+See also
+L<Term::CLI::Role::ArgumentSet|Term::CLI::Role::ArgumentSet/ATTRIBUTES>.
 
 =item B<callback> =E<gt> I<CodeRef>
 
@@ -395,7 +380,8 @@ Reference to an array containing C<Term::CLI::Command> object
 instances that describe the sub-commands that the command takes,
 or C<undef>.
 
-See also L<Term::CLI::Role::CommandSet|Term::CLI::Role::CommandSet/ATTRIBUTES>.
+See also
+L<Term::CLI::Role::CommandSet|Term::CLI::Role::CommandSet/ATTRIBUTES>.
 
 =item B<require_sub_command> =E<gt> I<Bool>
 
@@ -404,12 +390,13 @@ contains one of the sub-commands after this command. However, it may be
 desirable to allow the command to appear "naked", i.e. without a sub-command.
 For such cases, set the C<require_sub_command> to a false value.
 
-See also L<Term::CLI::Role::CommandSet|Term::CLI::Role::CommandSet/ATTRIBUTES>.
+See also
+L<Term::CLI::Role::CommandSet|Term::CLI::Role::CommandSet/ATTRIBUTES>.
 
 =item B<options> =E<gt> I<ArrayRef>
 
 Reference to an array containing command options in
-L<Getopt::Long>(3p) style, or C<undef>.
+L<Getopt::Long|Getopt::Long>(3p) style, or C<undef>.
 
 =item B<description> =E<gt> I<Str>
 
@@ -439,11 +426,11 @@ automatically.)
 =head1 INHERITED METHODS
 
 This class inherits all the attributes and accessors of
-L<Term::CLI::Element>(3p),
-L<Term::CLI::Role::CommandSet>(3p),
-L<Term::CLI::Role::HelpText>(3p),
+L<Term::CLI::Element|Term::CLI::Element>(3p),
+L<Term::CLI::Role::CommandSet|Term::CLI::Role::CommandSet>(3p),
+L<Term::CLI::Role::HelpText|Term::CLI::Role::HelpText>(3p),
 and
-L<Term::CLI::Role::ArgumentSet>(3p),
+L<Term::CLI::Role::ArgumentSet|Term::CLI::Role::ArgumentSet>(3p),
 most notably:
 
 =head2 Accessors
@@ -548,7 +535,8 @@ attribute has been set.
 =item B<options> ( [ I<ArrayRef> ] )
 X<options>
 
-I<ArrayRef> with command-line options in L<Getopt::Long>(3p) format.
+I<ArrayRef> with command-line options in L<Getopt::Long|Getopt::Long>(3p)
+format.
 
 =back
 
@@ -556,16 +544,17 @@ I<ArrayRef> with command-line options in L<Getopt::Long>(3p) format.
 
 =over
 
-=item B<complete> ( I<WORD>, ... )
+=item B<complete> ( I<TEXT>, I<STATE> )
 X<complete>
 
-The I<WORD> arguments make up the parameters to this command.
-Given those, this method attempts to generate possible completions
-for the last I<WORD> in the list.
+Called by L<Term::CLI::Role::CommandSet|Term::CLI::Role::CommandSet>'s
+L<complete_line|Term::CLI::Role::CommandSet/complete_line> method,
+or another C<Term::CLI::Command>'s C<complete> function.
 
 The method can complete options, sub-commands, and arguments.
 Completions of commands and arguments is delegated to the appropriate
-L<Term::CLI::Command> and L<Term::CLI::Argument> instances, resp.
+C<Term::CLI::Command> and L<Term::CLI::Argument|Term::CLI::Argument>
+instances, resp.
 
 =item B<option_names>
 X<option_names>
@@ -605,13 +594,14 @@ function.
 
 =head1 SEE ALSO
 
-L<Term::CLI::Argument>(3p),
-L<Term::CLI::Element>(3p),
-L<Term::CLI::Role::ArgumentSet>(3p),
-L<Term::CLI::Role::CommandSet>(3p),
-L<Term::CLI::Role::HelpText>(3p),
-L<Term::CLI>(3p),
-L<Getopt::Long>(3p).
+L<Term::CLI::Argument|Term::CLI::Argument>(3p),
+L<Term::CLI::Element|Term::CLI::Element>(3p),
+L<Term::CLI::Role::ArgumentSet|Term::CLI::Role::ArgumentSet>(3p),
+L<Term::CLI::Role::CommandSet|Term::CLI::Role::CommandSet>(3p),
+L<Term::CLI::Role::HelpText|Term::CLI::Role::HelpText>(3p),
+L<Term::CLI|Term::CLI>(3p),
+L<Term::CLI::Util|Term::CLI::Util>(3p),
+L<Getopt::Long|Getopt::Long>(3p).
 
 =head1 AUTHOR
 

--- a/lib/Term/CLI/Command/Help.pm
+++ b/lib/Term/CLI/Command/Help.pm
@@ -7,7 +7,7 @@
 #       Author:  Steven Bakker (SBAKKER), <sbakker@cpan.org>
 #      Created:  18/Feb/2018
 #
-#   Copyright (c) 2018 Steven Bakker
+#   Copyright (c) 2018-2022 Steven Bakker
 #
 #   This module is free software; you can redistribute it and/or modify
 #   it under the same terms as Perl itself. See "perldoc perlartistic."

--- a/lib/Term/CLI/Command/Help.pm
+++ b/lib/Term/CLI/Command/Help.pm
@@ -27,7 +27,7 @@ use version;
 use List::Util 1.23 qw( first min );
 use File::Which 1.09;
 use Types::Standard 1.000005 qw( ArrayRef Str );
-use Getopt::Long 2.38 qw( GetOptionsFromArray );
+use Term::CLI::Util qw( get_options_from_array );
 use Term::CLI::L10N qw( loc );
 
 use Pod::Text::Termcap    2.06;
@@ -312,50 +312,46 @@ sub _get_all_help {
 }
 
 sub complete {
-    my ( $self, @words ) = @_;
+    my ( $self, $text, $state ) = @_;
 
-    my $partial = $words[-1] // '';
+    my $processed       = $state->{processed}   //= [];
+    my $unprocessed     = $state->{unprocessed} //= [];
+    my $parsed_options  = $state->{options}     //= {};
 
     # uncoverable branch false
     if ( $self->has_options ) {
 
         Getopt::Long::Configure(qw(bundling require_order pass_through));
 
-        my $opt_specs = $self->options;
+        my %opt_result = get_options_from_array(
+            args         => $unprocessed,
+            spec         => $self->options,
+            result       => $parsed_options,
+            pass_through => 1,
+        );
 
-        my %parsed_opts;
+        my $double_dash = $opt_result{double_dash};
 
-        my $has_terminator = first { $_ eq '--' } @words[ 0 .. $#words - 1 ];
-
-        ## no critic (RequireCheckingReturnValueOfEval)
-        eval { GetOptionsFromArray( \@words, \%parsed_opts, @$opt_specs ) };
-
-        if ( !$has_terminator && @words <= 1 && $partial =~ /^-/x ) {
+        if ( !$double_dash && @{$unprocessed} == 0 && $text =~ /^-/x ) {
 
             # We have to complete a command-line option.
-            return
-                grep { rindex( $_, $partial, 0 ) == 0 } $self->option_names;
+            return grep { rindex( $_, $text, 0 ) == 0 } $self->option_names;
         }
     }
 
     my $cur_cmd_ref = $self->parent;
-    while (@words) {
-        my $new_cmd_ref = $cur_cmd_ref->find_command( $words[0] );
-        if ( !$new_cmd_ref ) {
-            last;
-        }
-        shift @words;
+    while (@$unprocessed) {
+        my $new_cmd_ref = $cur_cmd_ref->find_command( $unprocessed->[0] );
+
+        return () if !$new_cmd_ref;
+
+        push @{$processed}, shift @{$unprocessed};
         $cur_cmd_ref = $new_cmd_ref;
     }
 
-    if ( @words == 0 ) {
-        return $cur_cmd_ref->name;
-    }
-    if ( $cur_cmd_ref->has_commands && @words == 1 ) {
-        return
-            grep { rindex( $_, $partial, 0 ) == 0 }
-            $cur_cmd_ref->command_names;
-    }
+    return grep { rindex( $_, $text, 0 ) == 0 } $cur_cmd_ref->command_names
+        if $cur_cmd_ref->has_commands;
+
     return ();
 }
 

--- a/lib/Term/CLI/Element.pm
+++ b/lib/Term/CLI/Element.pm
@@ -91,12 +91,43 @@ In addition, it defines:
 
 =over
 
-=item B<complete> ( I<STR> )
+=item B<complete> ( I<TEXT>, I<STATE> )
 
-Return a list of strings that are possible completions for I<value>.
+Return a list of strings that are possible completions for I<TEXT>.
 By default, this method returns an empty list.
 
 Sub-classes should probably override this.
+
+I<STATE> is a C<HashRef> that contains the following elements:
+
+=over
+
+=item B<processed> =E<gt> I<ArrayRef>
+
+Refers to a list of words that have already been processed by parent
+(C<Term::CLI::Command>) objects.
+
+=item B<unprocessed> =E<gt> I<ArrayRef>
+
+Refers to a list of words leading up to (but not including) the
+I<TEXT> that have not yet been processed by parent objects.
+
+For L<Term::CLI::Command> objects this is typically a list of command
+line arguments and sub-commands.
+
+For L<Term::CLI::Argument> objects this will be empty.
+
+=item B<options> =E<gt> I<HashRef>
+
+Command line options that have been seen in the input line so far.
+
+=back
+
+For most simple cases, you would only need to examine I<TEXT> (and,
+for command objects, the C<unprocessed> list).
+
+The C<processed> list and C<options> hash can be used to implement context
+sensitive completion, however.
 
 =back
 

--- a/lib/Term/CLI/Element.pm
+++ b/lib/Term/CLI/Element.pm
@@ -7,7 +7,7 @@
 #       Author:  Steven Bakker (SBAKKER), <sbakker@cpan.org>
 #      Created:  22/01/18
 #
-#   Copyright (c) 2018 Steven Bakker
+#   Copyright (c) 2018-2022 Steven Bakker
 #
 #   This module is free software; you can redistribute it and/or modify
 #   it under the same terms as Perl itself. See "perldoc perlartistic."

--- a/lib/Term/CLI/Intro.pod
+++ b/lib/Term/CLI/Intro.pod
@@ -5,7 +5,7 @@
 #       Author:  Steven Bakker (SBAKKER), <Steven.Bakker@ams-ix.net>
 #      Created:  22/Feb/18
 #
-#   Copyright (c) 2018 Steven Bakker
+#   Copyright (c) 2022 Steven Bakker
 #
 #   This module is free software; you can redistribute it and/or modify
 #   it under the same terms as Perl itself. See "perldoc perlartistic."
@@ -23,10 +23,10 @@ Term::CLI::Intro - introduction to Term::CLI class/module structure
 =head1 DESCRIPTION
 
 This manual entry provides information on the class and module
-structure of the L<Term::CLI>(3p) library.
+structure of the L<Term::CLI|Term::CLI>(3p) library.
 
 For an introduction in the usage of this library, including code
-examples, see L<Term::CLI::Tutorial>(3p).
+examples, see L<Term::CLI::Tutorial|Term::CLI::Tutorial>(3p).
 
 =head1 MODULE SUMMARY
 
@@ -34,16 +34,28 @@ examples, see L<Term::CLI::Tutorial>(3p).
 
 =over 36
 
-=item L<Term::CLI::L10N>
+=item L<Term::CLI::L10N|Term::CLI::L10N>
 
-Localizations for L<Term::CLI> diagnostics. Defines and exports a
-L<loc|Term::CLI::L10N/loc> function. Based on L<Locale::Maketext>(3p).
+Localizations for L<Term::CLI|Term::CLI> diagnostics. Defines
+and exports a L<loc|Term::CLI::L10N/loc> function.  Based on
+L<Locale::Maketext|Locale::Maketext>(3p).
 
-=item L<Term::CLI::L10N::en>
+=item L<Term::CLI::L10N::en|Term::CLI::L10N::en>
 
-=item L<Term::CLI::L10N::nl>
+=item L<Term::CLI::L10N::nl|Term::CLI::L10N::nl>
 
 English and Dutch language localizations, resp.
+
+=back
+
+=head2 Utility Modules
+
+=over 36
+
+=item L<Term::CLI::Util|Term::CLI::Util>
+
+Utility functions used in other modules/classes, e.g.
+C<get_options_from_args> and C<is_prefix_str>.
 
 =back
 
@@ -51,56 +63,56 @@ English and Dutch language localizations, resp.
 
 =over 36
 
-=item L<Term::CLI::ReadLine>
+=item L<Term::CLI::ReadLine|Term::CLI::ReadLine>
 
-Wrapper around L<Term::ReadLine> to provide a single, global
-L<Term::ReadLine>(3p) instance.
+Wrapper around L<Term::ReadLine|Term::ReadLine> to provide a single,
+global L<Term::ReadLine|Term::ReadLine>(3p) instance.
 
-=item L<Term::CLI>
+=item L<Term::CLI|Term::CLI>
 
 CLI reader and parser class.
 
-=item L<Term::CLI::Base>
+=item L<Term::CLI::Base|Term::CLI::Base>
 
-Base class for L<Term::CLI>(3p) objects.
+Base class for L<Term::CLI|Term::CLI>(3p) objects.
 
-=item L<Term::CLI::Element>
+=item L<Term::CLI::Element|Term::CLI::Element>
 
 Base class for CLI syntax elements.
 
-=item L<Term::CLI::Command>
+=item L<Term::CLI::Command|Term::CLI::Command>
 
 CLI syntax element for (sub-)commands.
 
-=item L<Term::CLI::Command::Help>
+=item L<Term::CLI::Command::Help|Term::CLI::Command::Help>
 
 CLI syntax element for the C<help> command.
 
-=item L<Term::CLI::Argument>
+=item L<Term::CLI::Argument|Term::CLI::Argument>
 
 Base CLI syntax element or command line arguments.
 
-=item L<Term::CLI::Argument::Enum>
+=item L<Term::CLI::Argument::Enum|Term::CLI::Argument::Enum>
 
 CLI syntax element for arguments from a fixed set of strings.
 
-=item L<Term::CLI::Argument::Filename>
+=item L<Term::CLI::Argument::Filename|Term::CLI::Argument::Filename>
 
 CLI syntax element for file/directory name arguments.
 
-=item L<Term::CLI::Argument::Number>
+=item L<Term::CLI::Argument::Number|Term::CLI::Argument::Number>
 
 Base class for numeric arguments.
 
-=item L<Term::CLI::Argument::Number::Float>
+=item L<Term::CLI::Argument::Number::Float|Term::CLI::Argument::Number::Float>
 
 CLI syntax element for floating point number arguments.
 
-=item L<Term::CLI::Argument::Number::Int>
+=item L<Term::CLI::Argument::Number::Int|Term::CLI::Argument::Number::Int>
 
 CLI syntax element for integer arguments.
 
-=item L<Term::CLI::Argument::String>
+=item L<Term::CLI::Argument::String|Term::CLI::Argument::String>
 
 CLI syntax element for string arguments.
 
@@ -110,15 +122,17 @@ CLI syntax element for string arguments.
 
 =over 36
 
-=item L<Term::CLI::Role::CommandSet>
+=item L<Term::CLI::Role::CommandSet|Term::CLI::Role::CommandSet>
 
-Methods to deal with a list of L<Term::CLI::Command> objects.
+Methods to deal with a list of L<Term::CLI::Command|Term::CLI::Command>
+objects.
 
-=item L<Term::CLI::Role::ArgumentSet>
+=item L<Term::CLI::Role::ArgumentSet|Term::CLI::Role::ArgumentSet>
 
-Methods to deal with a list of L<Term::CLI::Argument> objects.
+Methods to deal with a list of L<Term::CLI::Argument|Term::CLI::Argument>
+objects.
 
-=item L<Term::CLI::Role::HelpText>
+=item L<Term::CLI::Role::HelpText|Term::CLI::Role::HelpText>
 
 Methods to provide help text on a command.
 
@@ -215,24 +229,24 @@ I<X> owns at most one I<Y> (i.e. "one to one").
 
 =head1 SEE ALSO
 
-L<Term::CLI::Tutorial>(3p).
+L<Term::CLI::Tutorial|Term::CLI::Tutorial>(3p).
 
-L<Term::CLI>(3p),
-L<Term::CLI::Argument>(3p),
-L<Term::CLI::Argument::Bool>(3p),
-L<Term::CLI::Argument::Enum>(3p),
-L<Term::CLI::Argument::FileName>(3p),
-L<Term::CLI::Argument::Number>(3p),
-L<Term::CLI::Argument::Number::Float>(3p),
-L<Term::CLI::Argument::Number::Int>(3p),
-L<Term::CLI::Argument::String>(3p),
-L<Term::CLI::Command>(3p),
-L<Term::CLI::L10N>(3p),
-L<Term::CLI::L10N::en>(3p),
-L<Term::CLI::L10N::nl>(3p),
-L<Term::CLI::Role::CommandSet>(3p),
-L<Term::CLI::Role::ArgumentSet>(3p),
-L<Term::ReadLine>(3p).
+L<Term::CLI|Term::CLI>(3p),
+L<Term::CLI::Argument|Term::CLI::Argument>(3p),
+L<Term::CLI::Argument::Bool|Term::CLI::Argument::Bool>(3p),
+L<Term::CLI::Argument::Enum|Term::CLI::Argument::Enum>(3p),
+L<Term::CLI::Argument::FileName|Term::CLI::Argument::FileName>(3p),
+L<Term::CLI::Argument::Number|Term::CLI::Argument::Number>(3p),
+L<Term::CLI::Argument::Number::Float|Term::CLI::Argument::Number::Float>(3p),
+L<Term::CLI::Argument::Number::Int|Term::CLI::Argument::Number::Int>(3p),
+L<Term::CLI::Argument::String|Term::CLI::Argument::String>(3p),
+L<Term::CLI::Command|Term::CLI::Command>(3p),
+L<Term::CLI::L10N|Term::CLI::L10N>(3p),
+L<Term::CLI::L10N::en|Term::CLI::L10N::en>(3p),
+L<Term::CLI::L10N::nl|Term::CLI::L10N::nl>(3p),
+L<Term::CLI::Role::CommandSet|Term::CLI::Role::CommandSet>(3p),
+L<Term::CLI::Role::ArgumentSet|Term::CLI::Role::ArgumentSet>(3p),
+L<Term::ReadLine|Term::ReadLine>(3p).
 
 =head1 AUTHOR
 
@@ -240,7 +254,7 @@ Steven Bakker E<lt>sbakker@cpan.orgE<gt>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (c) 2018 Steven Bakker
+Copyright (c) 2022 Steven Bakker
 
 This module is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself. See "perldoc perlartistic."

--- a/lib/Term/CLI/L10N.pm
+++ b/lib/Term/CLI/L10N.pm
@@ -5,7 +5,7 @@
 #       Author:  Steven Bakker (SBAKKER), <sbakker@cpan.org>
 #      Created:  27/02/18
 #
-#   Copyright (c) 2018 Steven Bakker; All rights reserved.
+#   Copyright (c) 2018-2022 Steven Bakker; All rights reserved.
 #
 #   This module is free software; you can redistribute it and/or modify
 #   it under the same terms as Perl itself. See "perldoc perlartistic."

--- a/lib/Term/CLI/L10N/en.pm
+++ b/lib/Term/CLI/L10N/en.pm
@@ -4,7 +4,7 @@
 #       Author:  Steven Bakker (SBAKKER), <sbakker@cpan.org>
 #      Created:  27/02/18
 #
-#   Copyright (c) 2018 Steven Bakker; All rights reserved.
+#   Copyright (c) 2018-2022 Steven Bakker; All rights reserved.
 #
 #   This module is free software; you can redistribute it and/or modify
 #   it under the same terms as Perl itself. See "perldoc perlartistic."

--- a/lib/Term/CLI/L10N/nl.pm
+++ b/lib/Term/CLI/L10N/nl.pm
@@ -4,7 +4,7 @@
 #       Author:  Steven Bakker (SBAKKER), <sbakker@cpan.org>
 #      Created:  27/02/18
 #
-#   Copyright (c) 2018 Steven Bakker; All rights reserved.
+#   Copyright (c) 2018-2022 Steven Bakker; All rights reserved.
 #
 #   This module is free software; you can redistribute it and/or modify
 #   it under the same terms as Perl itself. See "perldoc perlartistic."

--- a/lib/Term/CLI/ReadLine.pm
+++ b/lib/Term/CLI/ReadLine.pm
@@ -7,7 +7,7 @@
 #       Author:  Steven Bakker (SBAKKER), <sbakker@cpan.org>
 #      Created:  23/Jan/2018
 #
-#   Copyright (c) 2018 Steven Bakker
+#   Copyright (c) 2018-2022 Steven Bakker
 #
 #   This module is free software; you can redistribute it and/or modify
 #   it under the same terms as Perl itself. See "perldoc perlartistic."

--- a/lib/Term/CLI/Role/ArgumentSet.pm
+++ b/lib/Term/CLI/Role/ArgumentSet.pm
@@ -7,7 +7,7 @@
 #       Author:  Steven Bakker (SBAKKER), <sbakker@cpan.org>
 #      Created:  05/02/18
 #
-#   Copyright (c) 2018 Steven Bakker
+#   Copyright (c) 2018-2022 Steven Bakker
 #
 #   This module is free software; you can redistribute it and/or modify
 #   it under the same terms as Perl itself. See "perldoc perlartistic."

--- a/lib/Term/CLI/Role/CommandSet.pm
+++ b/lib/Term/CLI/Role/CommandSet.pm
@@ -7,7 +7,7 @@
 #       Author:  Steven Bakker (SBAKKER), <sbakker@cpan.org>
 #      Created:  05/02/18
 #
-#   Copyright (c) 2018 Steven Bakker
+#   Copyright (c) 2018-2022 Steven Bakker
 #
 #   This module is free software; you can redistribute it and/or modify
 #   it under the same terms as Perl itself. See "perldoc perlartistic."

--- a/lib/Term/CLI/Role/HelpText.pm
+++ b/lib/Term/CLI/Role/HelpText.pm
@@ -7,7 +7,7 @@
 #       Author:  Steven Bakker (SBAKKER), <sbakker@cpan.org>
 #      Created:  19/02/18
 #
-#   Copyright (c) 2018 Steven Bakker
+#   Copyright (c) 2018-2022 Steven Bakker
 #
 #   This module is free software; you can redistribute it and/or modify
 #   it under the same terms as Perl itself. See "perldoc perlartistic."

--- a/lib/Term/CLI/Tutorial.pod
+++ b/lib/Term/CLI/Tutorial.pod
@@ -1043,7 +1043,7 @@ Code:
                 arguments => [
                     Term::CLI::Argument::Bool->new(name => 'bool',
                         true_values  => [qw( 1 true on yes ok )],
-                        false_values => [qw( 1 false off no never )],
+                        false_values => [qw( 0 false off no never )],
                     )
 
                 ],

--- a/lib/Term/CLI/Tutorial.pod
+++ b/lib/Term/CLI/Tutorial.pod
@@ -294,7 +294,7 @@ So, now that we have the basic mechanism out of the way, let's
 add our first command, the highly useful C<exit>.
 
 =head2 The C<exit> command (optional argument)
-X<exit_command>
+X<exit command>
 
 From L<THE BSSH CONCEPT|/THE BSSH CONCEPT> section above:
 
@@ -626,6 +626,7 @@ same prefix (C<e>), so let's see what happens with the abbreviations:
     -- exit: 0
 
 =head2 The C<make> command (enum arguments)
+X<make command>
 
 From L<THE BSSH CONCEPT|/THE BSSH CONCEPT> section above:
 
@@ -1109,6 +1110,7 @@ sub-commands (the C<interface> command), or to create syntactic sugar
 (the C<do> command).
 
 =head2 Syntactic sugar: the C<do> command
+X<do command>
 
 The specification says:
 
@@ -1153,6 +1155,7 @@ Code:
     );
 
 =head2 Common argument(s): the C<interface> command
+X<interface command>
 
 The specification says:
 
@@ -1535,6 +1538,67 @@ For more details on the dirty secrets of signal handling, see the
 L<SIGNAL HANDLING section|Term::CLI::ReadLine/SIGNAL HANDLING>
 in L<Term::CLI::ReadLine>(3p).
 
+=head1 DYNAMIC COMPLETION LISTS
+
+Let's look at the L<interface command|/interface command> again
+(L<see above|/interface command>).
+
+The I<iface> argument is defined as a simple
+C<Term::CLI::Argument::String>, and so has no possibilities for
+completion.
+
+What if we want to enable completion for this argument, though? Well, the
+obvious choice is L<Term::CLI::Argument::Enum>, which we've seen before
+(See L<make|/make command> and L<do|/do command> above).
+
+We can query the system for a list of the available interfaces at
+object construction time, but what if we run this on a laptop where
+devices can be hot-plugged (USB dongles, etc.)?
+
+Well, this is where C<Term::CLI::Argument::Enum> has a trick up its sleeve.
+Instead of an ArrayRef, we can provide it with a CodeRef which will be called
+when the list of possible values has to be expanded.
+
+So, let's rewrite the C<interface> command definition. Instead of:
+
+	arguments => [
+		Term::CLI::Argument::String->new( name => 'iface' )
+	],
+
+We specify:
+
+	arguments => [
+		Term::CLI::Argument::Enum->new(
+			name => 'iface',
+			value_list => sub {
+				my $if_t = readpipe('ip link show 2>/dev/null') // '';
+				my @if_l = $if_t =~ /^ \d+ : \s (\S+): \s/gxms;
+				return \@if_l;
+			}
+		),
+	],
+
+This results in F<example_18_dynamic_enum.pl>:
+
+    bash$ perl tutorial/example_18_dynamic_enum.pl
+
+    [Welcome to BSSH]
+    bssh> interface <TAB><TAB>
+	lo        virbr0    virbr1    wlp113s0
+
+Now, when I plug in my USB-C dongle with an Ethernet adapter, I get:
+
+    bssh> interface <TAB><TAB>
+	enp0s13f0u3u1  lo   virbr0    virbr1   wlp113s0
+
+Neat, huh?
+
+In combination with the C<cache_values> flag, dynamic value lists can also
+be used to generate the value list once on demand (e.g. by querying a
+remote database) without affecting startup time of the application itself.
+
+See L<Term::CLI::Argument::Enum|Term::CLI::Argument::Enum> for more details.
+
 =head1 DEALING WITH HISTORY
 
 By default, the L<Term::CLI> objects do not try to read or write
@@ -1566,7 +1630,7 @@ on how to change the defaults.
 
 The above code will not save the command history if you call C<exit> from
 a callback function. The previously created C<exit> command
-(L<see above|/exit_command>) calls the C<execute_exit> callback, which calls
+(L<see above|/exit command>) calls the C<execute_exit> callback, which calls
 C<exit()>. As a result, the line with C<$term-E<gt>write_history()> is never
 reached.
 

--- a/lib/Term/CLI/Util.pm
+++ b/lib/Term/CLI/Util.pm
@@ -24,6 +24,7 @@ use 5.014;
 use warnings;
 use parent qw( Exporter );
 
+use List::Util qw( first );
 use Getopt::Long 2.38 qw( GetOptionsFromArray );
 use namespace::clean;
 
@@ -52,7 +53,7 @@ sub get_options_from_array {
 
     $result //= {};
 
-    my $double_dash = q{};
+    my $double_dash;
 
     Getopt::Long::Configure(
         qw(bundling require_order),
@@ -62,6 +63,8 @@ sub get_options_from_array {
     if ( $pass_through && $HAVE_OLD_GETOPT ) {
         $double_dash = first { $_ eq '--' } @{$arguments};
     }
+
+    $double_dash //= q{};
 
     my $error = q{};
     my $ok    = do {

--- a/lib/Term/CLI/Util.pm
+++ b/lib/Term/CLI/Util.pm
@@ -1,0 +1,338 @@
+#=============================================================================
+#
+#       Module:  Term::CLI::Util
+#
+#  Description:  Utility functions for Term::CLI
+#
+#       Author:  Steven Bakker (SBAKKER), <sbakker@cpan.org>
+#      Created:  21/01/2022
+#
+#   Copyright (c) 2022 Steven Bakker
+#
+#   This module is free software; you can redistribute it and/or modify
+#   it under the same terms as Perl itself. See "perldoc perlartistic."
+#
+#   This software is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+#=============================================================================
+
+package Term::CLI::Util 0.054004;
+
+use 5.014;
+use warnings;
+use parent qw( Exporter );
+
+use Getopt::Long 2.38 qw( GetOptionsFromArray );
+use namespace::clean;
+
+# When "pass_through" is enabled, Getopt::Long >= 2.51 will leave a
+# "--" in the argument list, but older versions won't.
+my $HAVE_OLD_GETOPT = $Getopt::Long::VERSION < 2.51;
+
+BEGIN {
+	our @EXPORT_OK   = qw(
+        get_options_from_array
+        is_prefix_str
+    );
+	our @EXPORT      = ();
+	our %EXPORT_TAGS = ( all => \@EXPORT_OK );
+}
+
+sub is_prefix_str {
+    my ($substr, $str) = @_;
+    return rindex( $str, $substr, 0 ) == 0;
+}
+
+sub get_options_from_array {
+    my %args = @_;
+    my ($arguments, $result, $opt_specs, $pass_through) =
+        @args{qw(args result spec pass_through)};
+
+    $result //= {};
+
+    my $double_dash = q{};
+
+    Getopt::Long::Configure(
+        qw(bundling require_order),
+        ($pass_through ? '' : 'no_') . 'pass_through'
+    );
+
+    if ( $pass_through && $HAVE_OLD_GETOPT ) {
+        $double_dash = first { $_ eq '--' } @{$arguments};
+    }
+
+    my $error = q{};
+    my $ok    = do {
+        local ( $SIG{__WARN__} ) = sub { chomp( $error = join( q{}, @_ ) ) };
+        GetOptionsFromArray( $arguments, $result, @{$opt_specs} );
+    };
+
+    if ( $pass_through && !$HAVE_OLD_GETOPT ) {
+        if ( @{$arguments} && $arguments->[0] eq '--' ) {
+            $double_dash = shift @{$arguments};
+        }
+    }
+
+    return (
+        success     => $ok,
+        error_msg   => $error,
+		$pass_through ? ( double_dash => $double_dash ne q{} ) : (),
+    );
+}
+
+1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+Term::CLI::Util - utility functions for Term::CLI(3p)
+
+=head1 SYNOPSIS
+
+ use Term::CLI::Util qw( :all );
+
+ use Data::Dumper;
+
+ my %result = get_options_from_array(
+    args         => \@ARGV,
+    spec         => [ 'verbose|v', 'debug|d' ]
+    result       => \(my %options),
+    pass_through => 1,
+ );
+
+ say "Result: ", Data::Dumper->Dump(
+    [ \%result, \%options, \@ARGV ],
+    [ 'result', 'options', 'ARGV' ]
+ );
+
+ is_prefix_str( 'foo', 'foobar' ); # returns true.
+ is_prefix_str( 'bar', 'foobar' ); # returns false.
+
+=head1 DESCRIPTION
+
+Provide utility functions for various modules in the
+L<Term::CLI|Term::CLI>(3p) collection.
+
+=head1 EXPORTED FUNCTIONS
+
+No functions are exported by default. Functions need be imported explicitly
+by name, or by specifying the C<:all> tag, which will import all functions.
+
+=head1 FUNCTIONS
+
+=over
+
+=item B<get_options_from_array>
+X<get_options_from_array>
+
+    HASH = get_options_from_array(
+        args => ArrayRef,
+        spec => ArrayRef,
+        [ result => HashRef, ]
+        [ pass_through => Bool, ]
+    );
+
+Parse the command line options in the C<args> array according to the options
+specified in the C<spec> array. Recognised options are stored in the C<result>
+hash.
+
+This is a fancy wrapper around
+L<GetOptionsFromArray|Getopt::Long/GetOptionsFromArray>
+from
+L<Getopt::Long|Getopt::Long>(3p).
+
+This function, however, sets the following configuration flags for
+C<Getopt::Long>: C<bundling>, C<require_order> and either C<pass_through>
+or C<no_pass_through>, depending on the C<pass_through> parameter it was
+given.
+
+Unlike C<Getopt::Long>, this function will remove the option terminating
+"double dash" (C<-->) argument from the argument list, even if
+C<pass_through> is true.
+
+The return value is a hash with the following keys:
+
+=over
+
+=item C<success>
+
+A boolean indicating whether the option parsing was successful or not. If
+false, the C<error_msg> key will hold a diagnostic message.
+
+=item C<error_msg>
+
+A string holding the error message from C<Getopt::Long>. If C<success> is
+true, this will be an empty string.
+
+=item C<double_dash>
+
+A boolean indicating whether option parsing was stopped due to encountering
+a C<--> word in the argument list.
+
+This is only present if C<pass_through> was specified with a true value.
+
+=back
+
+=item B<is_prefix_str>
+X<is_prefix_str>
+
+    BOOL = is_prefix_str( SUBSTR, STRING );
+
+Returns whether I<SUBSTR> is a prefix of I<STRING>.
+
+=back
+
+=head1 EXAMPLES
+
+Consider the following script, called C<getopt_test.pl>:
+
+    use 5.014;
+    use warnings;
+    use Data::Dumper;
+    use Term::CLI::Util qw( get_options_from_array );
+
+    my ($pass_through, @args) = @ARGV;
+
+    my %options;
+
+    my %result = get_options_from_array(
+        args         => \@args,
+        spec         => [ 'verbose|v+', 'debug|d' ],
+        result       => \%options,
+        pass_through => $pass_through,
+    );
+
+    print Data::Dumper->Dump(
+        [ \%result, \%options, \@args ],
+        [ '*result', '*options', '*args' ]
+    );
+
+=head2 With correct input
+
+With C<pass_through>:
+
+    $ perl getopt_test.pl 1 -vv --debug -- foo bar
+    %result = (
+                'success' => 1,
+                'error_msg' => '',
+                'double_dash' => 1
+              );
+    %options = (
+                 'debug' => 1,
+                 'verbose' => 2
+               );
+    @args = (
+              'foo',
+              'bar'
+            );
+
+Without C<pass_through>:
+
+    $ perl getopt_test.pl 0 -vv --debug -- foo bar
+    %result = (
+                'success' => 1,
+                'error_msg' => '',
+              );
+    %options = (
+                 'debug' => 1,
+                 'verbose' => 2
+               );
+    @args = (
+              'foo',
+              'bar'
+            );
+
+Note the difference in output: in the case where C<pass_through> is enabled,
+there is an entry in the result for C<double_dash> (which in this case is
+true).
+
+=head2 With incorrect input
+
+With C<pass_through>:
+
+    $ perl getopt_test.pl 1 -vv --debug --bad -- foo bar
+    %result = (
+                'success' => 1,
+                'error_msg' => '',
+                'double_dash' => ''
+              );
+    %options = (
+                 'verbose' => 2
+               );
+    @args = (
+              '--bad',
+              '--debug',
+              '--',
+              'foo',
+              'bar'
+            );
+
+Without C<pass_through>:
+
+    $ perl getopt_test.pl 0 -vv --debug -- foo bar
+	%result = (
+	            'success' => '',
+	            'error_msg' => 'Unknown option: bad'
+	          );
+	%options = (
+	             'debug' => 1,
+	             'verbose' => 2
+	           );
+	@args = (
+	          'foo',
+	          'bar'
+	        );
+
+=head1 SEE ALSO
+
+L<Term::CLI|Term::CLI>(3p),
+L<Getopt::Long|Getopt::Long>(3p).
+
+=head1 CAVEATS
+
+When C<pass_through> is enabled, L<Getopt::Long> should leave a
+C<--> in the argument list when it encounters it; however, versions
+before 2.51 do not do so.
+
+This module tries to compensate for that when it detects an older
+L<Getopt::Long|Getopt::Long> version by searching for C<--> in
+the argument list beforehand. There are still instances where this
+can go wrong, though:
+
+=over
+
+=item *
+
+Input is C<--foo -- --verbose> and option C<foo> happens to take an
+argument.
+
+=item *
+
+Input is I<--opt1 arg1 arg2> and I<arg2> happens to be C<-->.
+
+=back
+
+However, since the C<double_dash> flag is really only used in command
+completion, this is not a very major issue.
+
+=head1 AUTHOR
+
+Steven Bakker E<lt>Steven.Bakker@ams-ix.netE<gt>, AMS-IX B.V.; 2022.
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (c) 2022 AMS-IX B.V.; All rights reserved.
+
+This module is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself. See "perldoc perlartistic."
+
+This software is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+=cut

--- a/scratch/fix_copyright.pl
+++ b/scratch/fix_copyright.pl
@@ -1,0 +1,53 @@
+#!/usr/bin/perl
+#
+# usage: perl fix_copyright.pl 0.02 lib/
+
+use 5.014_001;
+use warnings;
+use Time::Piece;
+
+my $NOW  = localtime(time);
+my $YEAR = $NOW->year;
+
+my $USAGE = "usage: $0 file ...\n";
+
+if (!@ARGV || @ARGV < 2 || $ARGV[0] =~ /^-/) {
+    die $USAGE;
+}
+
+local($^I) = '.bak';
+local($/)  = undef;
+
+while (<>) {
+    # Fix version number.
+    s(  ^
+        (?<head>   \h* \# \h* )?
+        (?<copyright> Copyright \h+ \([Cc]\) \h+ )
+        (?<year>    \d+)
+        (?<tail>    .*?)
+        $
+    )(
+        $+{head}
+        . new_copyright($+{copyright})
+        . new_year($+{year})
+        . $+{tail}
+    )exm;
+    print;
+}
+
+sub new_year {
+    my ($old_year) = @_;
+
+    return $old_year if $old_year eq $YEAR;
+    my ($low, $high) = split qr{-}, $old_year, 2;
+    return $old_year if $high && $high eq $YEAR;
+    return "$low-$YEAR";
+}
+
+sub new_copyright {
+    my ($text) = @_;
+
+    $text =~ s/copyright/Copyright/gxsmi;
+    $text =~ s/\( C \)/(c)/gxsm;
+    return $text;
+}

--- a/t/000-compile.t
+++ b/t/000-compile.t
@@ -1,6 +1,6 @@
 #!perl
 #
-# Copyright (C) 2018, Steven Bakker.
+# Copyright (c) 2018-2022, Steven Bakker.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the same terms as Perl 5.14.0. For more details, see the full text

--- a/t/015-Term-CLI-Element.t
+++ b/t/015-Term-CLI-Element.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -T
 #
-# Copyright (C) 2018, Steven Bakker.
+# Copyright (c) 2018-2022, Steven Bakker.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the same terms as Perl 5.14.0. For more details, see the full text

--- a/t/020-Term-CLI-Argument.t
+++ b/t/020-Term-CLI-Argument.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -T
 #
-# Copyright (C) 2018, Steven Bakker.
+# Copyright (c) 2018-2022, Steven Bakker.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the same terms as Perl 5.14.0. For more details, see the full text

--- a/t/023-Term-CLI-Argument-String.t
+++ b/t/023-Term-CLI-Argument-String.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -T
 #
-# Copyright (C) 2018, Steven Bakker.
+# Copyright (c) 2018-2022, Steven Bakker.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the same terms as Perl 5.14.0. For more details, see the full text

--- a/t/025-Term-CLI-Argument-Enum.t
+++ b/t/025-Term-CLI-Argument-Enum.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -T
 #
-# Copyright (C) 2018, Steven Bakker.
+# Copyright (c) 2018-2022, Steven Bakker.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the same terms as Perl 5.14.0. For more details, see the full text

--- a/t/026-Term-CLI-Argument-Enum-Dynamic.t
+++ b/t/026-Term-CLI-Argument-Enum-Dynamic.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -T
 #
-# Copyright (C) 2018, Steven Bakker.
+# Copyright (c) 2018-2022, Steven Bakker.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the same terms as Perl 5.14.0. For more details, see the full text

--- a/t/027-Term-CLI-Argument-Bool.t
+++ b/t/027-Term-CLI-Argument-Bool.t
@@ -76,12 +76,12 @@ sub check_complete: Test(6) {
         "complete returns (@expected) for '$partial'");
 
     $partial = 'F';
-    @expected = sort qw( False );
+    @expected = sort qw( FALSE );
     is_deeply( [$arg->complete($partial)], \@expected,
         "complete returns (@expected) for '$partial'");
 
     $partial = 'O';
-    @expected = sort qw( On Ok Off );
+    @expected = sort qw( ON OK OFF );
     is_deeply( [$arg->complete($partial)], \@expected,
         "complete returns (@expected) for '$partial'");
 

--- a/t/027-Term-CLI-Argument-Bool.t
+++ b/t/027-Term-CLI-Argument-Bool.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -T
 #
-# Copyright (C) 2018, Steven Bakker.
+# Copyright (c) 2018-2022, Steven Bakker.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the same terms as Perl 5.14.0. For more details, see the full text

--- a/t/028-Term-CLI-Argument-Enum-Cache.t
+++ b/t/028-Term-CLI-Argument-Enum-Cache.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -T
 #
-# Copyright (C) 2022, Steven Bakker.
+# Copyright (c) 2022, Steven Bakker.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the same terms as Perl 5.14.0. For more details, see the full text

--- a/t/028-Term-CLI-Argument-Enum-Cache.t
+++ b/t/028-Term-CLI-Argument-Enum-Cache.t
@@ -1,0 +1,119 @@
+#!/usr/bin/perl -T
+#
+# Copyright (C) 2022, Steven Bakker.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the same terms as Perl 5.14.0. For more details, see the full text
+# of the licenses in the directory LICENSES.
+#
+
+use 5.014_001;
+use warnings;
+
+sub Main {
+    Term_CLI_Argument_Enum_test->SKIP_CLASS(
+        ($::ENV{SKIP_ARGUMENT})
+            ? "disabled in environment"
+            : 0
+    );
+    Term_CLI_Argument_Enum_test->runtests();
+    return;
+}
+
+package Term_CLI_Argument_Enum_test {
+
+use parent 0.225 qw( Test::Class );
+
+use Test::More 1.001002;
+use Test::Exception 0.35;
+use Term::CLI::Argument::Enum;
+use Term::CLI::L10N;
+
+my $ARG_NAME= 'test_enum';
+my @ENUM_VALUES = qw( foo bar baz );
+
+# Untaint the PATH.
+$::ENV{PATH} = '/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin';
+
+my $Call_count = 0;
+
+sub get_value_list {
+    $Call_count++;
+    my @l = map { "$_-$Call_count" } @ENUM_VALUES;
+    return \@l;
+}
+
+sub startup : Test(startup => 1) {
+    my $self = shift;
+
+    Term::CLI::L10N->set_language('en');
+
+    my $arg = Term::CLI::Argument::Enum->new(
+        name => $ARG_NAME,
+        value_list => \&get_value_list,
+    );
+
+    isa_ok( $arg, 'Term::CLI::Argument::Enum', 'Term::CLI::Argument::Enum->new' );
+    $self->{arg} = $arg;
+    return;
+}
+
+sub check_uncached: Test(2) {
+    my $self = shift;
+    my $arg = $self->{arg};
+
+    $arg->cache_values(0);
+
+    my $count = $Call_count = 0;
+
+    my ($got, @expected);
+
+    $got = $arg->values;
+    $count++;
+    @expected = map { "$_-$count" } @ENUM_VALUES;
+
+    is_deeply( $got, \@expected,
+        'cache=0; enum value list 1 is dynamic',
+    );
+
+    $got = $arg->values;
+    $count++;
+    @expected = map { "$_-$count" } @ENUM_VALUES;
+
+    is_deeply( $got, \@expected,
+        'cache=0; enum value list 2 is dynamic',
+    );
+
+    return;
+}
+
+sub check_cached: Test(2) {
+    my $self = shift;
+    my $arg = $self->{arg};
+
+    $arg->cache_values(1);
+
+    my $count = $Call_count = 10;
+
+    my ($got, @expected);
+
+    $got = $arg->values;
+    $count++;
+
+    @expected = map { "$_-$count" } @ENUM_VALUES;
+
+    is_deeply( $got, \@expected,
+        'cache=1; enum value list 1 is correct',
+    );
+
+    $got = $arg->values;
+    is_deeply( $got, \@expected,
+        'cache=1; enum value list 2 is unchanged',
+    );
+
+    return;
+}
+
+}
+
+Main();

--- a/t/030-Term-CLI-Argument-Filename.t
+++ b/t/030-Term-CLI-Argument-Filename.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -T
 #
-# Copyright (C) 2018, Steven Bakker.
+# Copyright (c) 2018-2022, Steven Bakker.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the same terms as Perl 5.14.0. For more details, see the full text

--- a/t/035-Term-CLI-Argument-Number.t
+++ b/t/035-Term-CLI-Argument-Number.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -T
 #
-# Copyright (C) 2018, Steven Bakker.
+# Copyright (c) 2018-2022, Steven Bakker.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the same terms as Perl 5.14.0. For more details, see the full text

--- a/t/040-Term-CLI-Argument-Number-Int.t
+++ b/t/040-Term-CLI-Argument-Number-Int.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -T
 #
-# Copyright (C) 2018, Steven Bakker.
+# Copyright (c) 2018-2022, Steven Bakker.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the same terms as Perl 5.14.0. For more details, see the full text

--- a/t/045-Term-CLI-Argument-Number-Float.t
+++ b/t/045-Term-CLI-Argument-Number-Float.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -T
 #
-# Copyright (C) 2018, Steven Bakker.
+# Copyright (c) 2018-2022, Steven Bakker.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the same terms as Perl 5.14.0. For more details, see the full text

--- a/t/050-Term-CLI-Command.t
+++ b/t/050-Term-CLI-Command.t
@@ -148,29 +148,39 @@ sub check_complete_command: Test(5) {
 
     my @command_names = $cmd->command_names;
 
+    my ($text, @cmd_line);
     my @got;
 
-    @got = $cmd->complete();
+    $text = pop @cmd_line;
+    @got = $cmd->complete($text, { unprocessed => [@cmd_line] });
     is_deeply( \@got, \@command_names,
         "complete returns (@command_names) for ()")
     or diag("complete returned: (", join(", ", map {"'$_'"} @got), ")");
 
-    @got = $cmd->complete('');
+    @cmd_line = (q{});
+    $text = pop @cmd_line;
+    @got = $cmd->complete($text, { unprocessed => [@cmd_line] });
     is_deeply( \@got, \@command_names,
         "complete returns (@command_names) for ''")
     or diag("complete returned: (", join(", ", map {"'$_'"} @got), ")");
 
-    @got = $cmd->complete('d');
+    @cmd_line = (q{d});
+    $text = pop @cmd_line;
+    @got = $cmd->complete($text, { unprocessed => [@cmd_line] });
     is_deeply( \@got, [qw(date debug)],
         "complete returns (date debug) for 'd'")
     or diag("complete returned: (", join(", ", map {"'$_'"} @got), ")");
 
-    @got = $cmd->complete('t');
+    @cmd_line = (q{t});
+    $text = pop @cmd_line;
+    @got = $cmd->complete($text, { unprocessed => [@cmd_line] });
     is_deeply( \@got, [qw(time)],
         "complete returns (time) for 't'")
     or diag("complete returned: (", join(", ", map {"'$_'"} @got), ")");
 
-    @got = $cmd->complete('X');
+    @cmd_line = (q{X});
+    $text = pop @cmd_line;
+    @got = $cmd->complete($text, { unprocessed => [@cmd_line] });
     is_deeply( \@got, [],
         "complete returns () for 'X'")
     or diag("complete returned: (", join(", ", map {"'$_'"} @got), ")");
@@ -205,19 +215,19 @@ sub check_complete_options: Test(5) {
 
     # The "--" should end the list of options, so a complete should
     # return the list of sub-commands.
-    @got = $cmd->complete('--', '');
+    @got = $cmd->complete('', { unprocessed => ['--'] } );
     my @command_names = $cmd->command_names;
     is_deeply( \@got, \@command_names,
-        "complete returns (@command_names) for ('--', '')")
+        "complete returns (@command_names) for ('-- ')")
     or diag("complete returned: (", join(", ", map {"'$_'"} @got), ")");
 
 
     # After a "--", the "--v" should not be seen as a (partial) option,
     # and "normal" completion should commence; in this case, it should
     # result in an empty list.
-    @got = $cmd->complete('--', '--v');
+    @got = $cmd->complete('--v', { unprocessed => ['--'] });
     is_deeply( \@got, [],
-        "complete returns () for ('--', '--v')")
+        "complete returns () for ('-- --v')")
     or diag("complete returned: (", join(", ", map {"'$_'"} @got), ")");
     return;
 }
@@ -229,21 +239,24 @@ sub check_ambiguous_complete: Test(3) {
 
     # "show debug|date";
 
+    my ($text, @cmd_line);
     my @got;
-    my @cmd_line;
 
     @cmd_line = qw( d );
-    @got = $cmd->complete(@cmd_line);
+    $text = pop @cmd_line;
+    @got = $cmd->complete($text, { unprocessed => [@cmd_line] });
     is_deeply( \@got, [qw( date debug )],
         "complete returns (date debug) for (d)" );
 
     @cmd_line = qw( d o );
-    @got = $cmd->complete(@cmd_line);
+    $text = pop @cmd_line;
+    @got = $cmd->complete($text, { unprocessed => [@cmd_line] });
     is_deeply( \@got, [],
         "complete returns () for (d o)" );
 
     @cmd_line = qw( de o );
-    @got = $cmd->complete(@cmd_line);
+    $text = pop @cmd_line;
+    @got = $cmd->complete($text, { unprocessed => [@cmd_line] });
     is_deeply( \@got, ['out'],
         "complete returns (out) for (de o)" );
     return;
@@ -258,19 +271,23 @@ sub check_complete_show_param: Test(3) {
 
     my @got;
     my @cmd_line;
+    my $text;
 
     @cmd_line = qw( --verbose param time );
-    @got = $cmd->complete(@cmd_line);
+    $text = pop @cmd_line;
+    @got = $cmd->complete($text, { unprocessed => [@cmd_line] });
     is_deeply( \@got, ['timeout'],
         "complete returns (timeout) for (--verbose param time)" );
 
     @cmd_line = qw( --verbose param time i );
-    @got = $cmd->complete(@cmd_line);
+    $text = pop @cmd_line;
+    @got = $cmd->complete($text, { unprocessed => [@cmd_line] });
     is_deeply( \@got, ['in'],
         "complete returns (in) for (--verbose param time i)" );
 
     @cmd_line = qw( --verbose param time in useless );
-    @got = $cmd->complete(@cmd_line);
+    $text = pop @cmd_line;
+    @got = $cmd->complete($text, { unprocessed => [@cmd_line] });
     is_deeply( \@got, [],
         "complete returns () for (--verbose param time in useless)" );
     return;

--- a/t/050-Term-CLI-Command.t
+++ b/t/050-Term-CLI-Command.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -T
 #
-# Copyright (C) 2018, Steven Bakker.
+# Copyright (c) 2018-2022, Steven Bakker.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the same terms as Perl 5.14.0. For more details, see the full text

--- a/t/055-Term-CLI.t
+++ b/t/055-Term-CLI.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -T
 #
-# Copyright (C) 2018, Steven Bakker.
+# Copyright (c) 2018-2022, Steven Bakker.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the same terms as Perl 5.14.0. For more details, see the full text

--- a/t/055-Term-CLI.t
+++ b/t/055-Term-CLI.t
@@ -27,7 +27,7 @@ use parent 0.225 qw( Test::Class );
 use Test::More 1.001002;
 use Test::Exception 0.35;
 use Test::Output 1.02;
-use Test::MockModule 0.171 qw( strict );
+use Test::MockModule 0.16 qw( strict );
 
 use FindBin 1.50;
 use Term::CLI;

--- a/t/060-Term-CLI-ReadLine.t
+++ b/t/060-Term-CLI-ReadLine.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -T
 #
-# Copyright (C) 2018, Steven Bakker.
+# Copyright (c) 2018-2022, Steven Bakker.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the same terms as Perl 5.14.0. For more details, see the full text

--- a/t/065-Term-CLI-Command-Help.t
+++ b/t/065-Term-CLI-Command-Help.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# Copyright (C) 2018, Steven Bakker.
+# Copyright (c) 2018-2022, Steven Bakker.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the same terms as Perl 5.14.0. For more details, see the full text

--- a/t/070-Term-CLI-Role-HelpText.t
+++ b/t/070-Term-CLI-Role-HelpText.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -T
 #
-# Copyright (C) 2018, Steven Bakker.
+# Copyright (c) 2018-2022, Steven Bakker.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the same terms as Perl 5.14.0. For more details, see the full text

--- a/t/075-Term-CLI-History.t
+++ b/t/075-Term-CLI-History.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -T
 #
-# Copyright (C) 2018, Steven Bakker.
+# Copyright (c) 2018-2022, Steven Bakker.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the same terms as Perl 5.14.0. For more details, see the full text

--- a/t/080-Term-CLI-L10N-nl.t
+++ b/t/080-Term-CLI-L10N-nl.t
@@ -1,6 +1,6 @@
 #!perl
 #
-# Copyright (C) 2018, Steven Bakker.
+# Copyright (c) 2018-2022, Steven Bakker.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the same terms as Perl 5.14.0. For more details, see the full text

--- a/tutorial/example_13_set_command.pl
+++ b/tutorial/example_13_set_command.pl
@@ -231,7 +231,7 @@ push @commands, Term::CLI::Command->new(
                 Term::CLI::Argument::Bool->new(
                     name         => 'bool',
                     true_values  => [qw( 1 true on yes ok )],
-                    false_values => [qw( 1 false off no never )],
+                    false_values => [qw( 0 false off no never )],
                 )
 
             ],

--- a/tutorial/example_14_sub_cmd_and_args.pl
+++ b/tutorial/example_14_sub_cmd_and_args.pl
@@ -244,7 +244,7 @@ push @commands, Term::CLI::Command->new(
                 Term::CLI::Argument::Bool->new(
                     name         => 'bool',
                     true_values  => [qw( 1 true on yes ok )],
-                    false_values => [qw( 1 false off no never )],
+                    false_values => [qw( 0 false off no never )],
                 )
 
             ],

--- a/tutorial/example_15_debug_command.pl
+++ b/tutorial/example_15_debug_command.pl
@@ -245,7 +245,7 @@ push @commands, Term::CLI::Command->new(
                 Term::CLI::Argument::Bool->new(
                     name         => 'bool',
                     true_values  => [qw( 1 true on yes ok )],
-                    false_values => [qw( 1 false off no never )],
+                    false_values => [qw( 0 false off no never )],
                 )
 
             ],

--- a/tutorial/example_16_options.pl
+++ b/tutorial/example_16_options.pl
@@ -260,7 +260,7 @@ push @commands, Term::CLI::Command->new(
                 Term::CLI::Argument::Bool->new(
                     name         => 'bool',
                     true_values  => [qw( 1 true on yes ok )],
-                    false_values => [qw( 1 false off no never )],
+                    false_values => [qw( 0 false off no never )],
                 )
 
             ],

--- a/tutorial/example_17_suspend.pl
+++ b/tutorial/example_17_suspend.pl
@@ -367,6 +367,7 @@ push @commands, Term::CLI::Command->new(
         . "signal and return control to the shell.",
     callback => sub {
         my ( $cmd, %args ) = @_;
+        return %args if $args{status} < 0;
         local ( $SIG{TSTP} ) = 'DEFAULT';
         kill 'TSTP', $$;
         return %args;

--- a/tutorial/example_17_suspend.pl
+++ b/tutorial/example_17_suspend.pl
@@ -260,7 +260,7 @@ push @commands, Term::CLI::Command->new(
                 Term::CLI::Argument::Bool->new(
                     name         => 'bool',
                     true_values  => [qw( 1 true on yes ok )],
-                    false_values => [qw( 1 false off no never )],
+                    false_values => [qw( 0 false off no never )],
                 )
 
             ],

--- a/tutorial/example_18_dynamic_enum.pl
+++ b/tutorial/example_18_dynamic_enum.pl
@@ -1,0 +1,395 @@
+#!/usr/bin/env perl
+
+use 5.014;
+use warnings;
+
+use FindBin;
+use lib ("$FindBin::Bin/../lib");
+use Data::Dumper;
+
+use Term::CLI;
+
+$SIG{INT} = $SIG{TSTP} = 'IGNORE';
+
+my $term = Term::CLI->new(
+    name    => 'bssh',               # A basically simple shell.
+    skip    => qr/^\s*(?:#.*)?$/,    # Skip comments and empty lines.
+    prompt  => 'bssh> ',             # A more descriptive prompt.
+    cleanup => sub {
+        my ($term) = @_;
+        $term->write_history()
+            or warn "cannot write history: " . $term->error . "\n";
+    },
+);
+
+my @commands;
+
+push @commands, Term::CLI::Command->new(
+    name        => 'exit',
+    summary     => 'exit B<bssh>',
+    description => "Exit B<bssh> with code I<excode>,\n"
+        . "or C<0> if no exit code is given.",
+    callback => sub {
+        my ( $cmd, %args ) = @_;
+        return %args if $args{status} < 0;
+        execute_exit( $cmd, @{ $args{arguments} } );
+        return %args;
+    },
+    arguments => [
+        Term::CLI::Argument::Number::Int->new(    # Integer
+            name      => 'excode',
+            min       => 0,          # non-negative
+            inclusive => 1,          # "0" is allowed
+            min_occur => 0,          # occurrence is optional
+            max_occur => 1,          # no more than once
+        ),
+    ],
+);
+
+sub execute_exit {
+    my ( $cmd, $excode ) = @_;
+    $excode //= 0;
+    say "-- exit: $excode";
+    exit $excode;
+}
+
+push @commands, Term::CLI::Command::Help->new();
+
+push @commands, Term::CLI::Command->new(
+    name        => 'echo',
+    summary     => 'print arguments to F<stdout>',
+    description => "The C<echo> command prints its arguments\n"
+        . "to F<stdout>, separated by spaces, and\n"
+        . "terminated by a newline.\n",
+    arguments =>
+        [ Term::CLI::Argument::String->new( name => 'arg', occur => 0 ), ],
+    callback => sub {
+        my ( $cmd, %args ) = @_;
+        return %args if $args{status} < 0;
+        say "@{$args{arguments}}";
+        return %args;
+    }
+);
+
+push @commands, Term::CLI::Command->new(
+    name        => 'make',
+    summary     => 'make I<target> at time I<when>',
+    description => "Make I<target> at time I<when>.\n"
+        . "Possible values for I<target> are:\n"
+        . "C<love>, C<money>.\n"
+        . "Possible values for I<when> are:\n"
+        . "C<now>, C<never>, C<later>, or C<forever>.",
+    arguments => [
+        Term::CLI::Argument::Enum->new(
+            name       => 'target',
+            value_list => [qw( love money )],
+        ),
+        Term::CLI::Argument::Enum->new(
+            name       => 'when',
+            value_list => [qw( now later never forever )],
+        ),
+    ],
+    callback => sub {
+        my ( $cmd, %args ) = @_;
+        return %args if $args{status} < 0;
+        my @args = @{ $args{arguments} };
+        say "making $args[0] $args[1]";
+        return %args;
+    }
+);
+
+push @commands, Term::CLI::Command->new(
+    name        => 'ls',
+    summary     => 'list file(s)',
+    description => "List file(s) given by the arguments.\n"
+        . "If no arguments are given, the command\n"
+        . "will list the current directory.",
+    arguments =>
+        [ Term::CLI::Argument::Filename->new( name => 'arg', occur => 0 ), ],
+    callback => sub {
+        my ( $cmd, %args ) = @_;
+        return %args if $args{status} < 0;
+        my @args = @{ $args{arguments} };
+        system( 'ls', @args );
+        $args{status} = $?;
+        return %args;
+    }
+);
+
+push @commands, Term::CLI::Command->new(
+    name        => 'cp',
+    summary     => 'copy files',
+    description => "Copy files. The last argument in the\n"
+        . "list is the destination.\n",
+    arguments => [
+        Term::CLI::Argument::Filename->new(
+            name      => 'path',
+            min_occur => 2,
+            max_occur => 0
+        ),
+    ],
+    callback => sub {
+        my ( $cmd, %args ) = @_;
+        return %args if $args{status} < 0;
+        my @src = @{ $args{arguments} };
+        my $dst = pop @src;
+
+        say "command:     " . $cmd->name;
+        say "source:      " . join( ', ', @src );
+        say "destination: " . $dst;
+
+        return %args;
+    }
+);
+
+push @commands, Term::CLI::Command->new(
+    name        => 'sleep',
+    summary     => 'sleep for I<time> seconds',
+    description => "Sleep for I<time> seconds.\n"
+        . "Report the actual time spent sleeping.\n"
+        . "This number can be smaller than I<time>\n"
+        . "in case of an interruption (e.g. INT signal).",
+    arguments => [
+        Term::CLI::Argument::Number::Int->new(
+            name      => 'time',
+            min       => 1,
+            inclusive => 1
+        ),
+    ],
+    callback => sub {
+        my ( $cmd, %args ) = @_;
+        return %args if $args{status} < 0;
+
+        my $time = $args{arguments}->[0];
+
+        say "-- sleep: $time";
+
+        # Make sure we can interrupt the sleep() call.
+        my $slept = do {
+            local ( $::SIG{INT} ) = local ( $::SIG{QUIT} ) = sub {
+                say STDERR "(interrupted by $_[0])";
+            };
+            sleep($time);
+        };
+
+        say "-- woke up after $slept sec", $slept == 1 ? '' : 's';
+        return %args;
+    }
+);
+
+push @commands, Term::CLI::Command->new(
+    name        => 'show',
+    options     => ['verbose|v'],
+    summary     => 'show system properties',
+    description => "Show some system-related information,\n"
+        . "such as the system clock or load average.",
+    commands => [
+        Term::CLI::Command->new(
+            name        => 'clock',
+            options     => ['timezone|tz|t=s'],
+            summary     => 'show system time',
+            description => 'Show system time and date.',
+            callback    => \&do_show_clock,
+        ),
+        Term::CLI::Command->new(
+            name        => 'load',
+            summary     => 'show system load',
+            description => 'Show system load averages.',
+            callback    => sub {
+                my ( $self, %args ) = @_;
+                return %args if $args{status} < 0;
+                system('uptime');
+                $args{status} = $?;
+                return %args;
+            },
+        ),
+        Term::CLI::Command->new(
+            name        => 'terminal',
+            summary     => 'show terminal information',
+            description => 'Show terminal information.',
+            callback    => sub {
+                my ( $self, %args ) = @_;
+                return %args if $args{status} < 0;
+                my ( $rows, $cols ) = $self->root_node->term->get_screen_size;
+                say "type $ENV{TERM}; rows $rows; columns $cols";
+                $args{status} = 0;
+                return %args;
+            },
+        ),
+    ],
+);
+
+sub do_show_clock {
+    my ( $self, %args ) = @_;
+    return %args if $args{status} < 0;
+    my $opt = $args{options};
+
+    local ( $::ENV{TZ} );
+    if ( $opt->{timezone} ) {
+        $::ENV{TZ} = $opt->{timezone};
+    }
+    say scalar(localtime);
+    return %args;
+}
+
+push @commands, Term::CLI::Command->new(
+    name        => 'set',
+    summary     => 'set CLI parameters',
+    description => 'Set various CLI parameters.',
+    commands    => [
+        Term::CLI::Command->new(
+            name        => 'delimiters',
+            summary     => 'set word delimiter(s)',
+            description => 'Set the word delimiter(s) to I<string>.',
+            arguments   =>
+                [ Term::CLI::Argument::String->new( name => 'string' ) ],
+            callback => sub {
+                my ( $self, %args ) = @_;
+                return %args if $args{status} < 0;
+                my $delimiters = $args{arguments}->[0];
+                $self->root_node->word_delimiters($delimiters);
+                say "Delimiters set to [$delimiters]";
+                return %args;
+            }
+        ),
+        Term::CLI::Command->new(
+            name        => 'verbose',
+            summary     => 'set verbose flag',
+            description => 'Set the verbose flag for the program.',
+            arguments   => [
+                Term::CLI::Argument::Bool->new(
+                    name         => 'bool',
+                    true_values  => [qw( 1 true on yes ok )],
+                    false_values => [qw( 1 false off no never )],
+                )
+
+            ],
+            callback => sub {
+                my ( $self, %args ) = @_;
+                return %args if $args{status} < 0;
+                my $bool = $args{arguments}->[0];
+                say "Setting verbose to $bool";
+                return %args;
+            }
+        ),
+    ],
+);
+
+push @commands, Term::CLI::Command->new(
+    name        => 'do',
+    summary     => 'Do I<action> while I<activity>',
+    description => "Do I<action> while I<activity>.\n"
+        . "Possible values for I<action> are:\n"
+        . "C<nothing>, C<something>.\n"
+        . "Possible values for I<activity> are:\n"
+        . "C<sleeping>, C<working>.",
+    arguments => [
+        Term::CLI::Argument::Enum->new(
+            name       => 'action',
+            value_list => [qw( something nothing )],
+        ),
+    ],
+    commands => [
+        Term::CLI::Command->new(
+            name      => 'while',
+            arguments => [
+                Term::CLI::Argument::Enum->new(
+                    name       => 'activity',
+                    value_list => [qw( eating sleeping )],
+                ),
+            ],
+        ),
+    ],
+    callback => sub {
+        my ( $cmd, %args ) = @_;
+        return %args if $args{status} < 0;
+        my @args = @{ $args{arguments} };
+        say "doing $args[0] while $args[1]";
+        return %args;
+    }
+);
+
+push @commands, Term::CLI::Command->new(
+    name        => 'interface',
+    summary     => 'Turn I<iface> up or down',
+    description => "Turn the I<iface> interface up or down.",
+    arguments   => [
+        Term::CLI::Argument::Enum->new(
+            name => 'iface',
+            value_list => sub {
+                my $if_t = readpipe('ip link show 2>/dev/null') // '';
+                my @if_l = $if_t =~ /^ \d+ : \s (\S+): \s/gxms;
+                return \@if_l;
+            }
+        ),
+    ],
+    commands    => [
+        Term::CLI::Command->new(
+            name        => 'up',
+            summary     => 'Bring I<iface> up',
+            description => 'Bring the I<iface> interface up.',
+            callback    => sub {
+                my ( $cmd, %args ) = @_;
+                return %args if $args{status} < 0;
+                my @args = @{ $args{arguments} };
+                say "bringing up $args[0]";
+                return %args;
+            }
+        ),
+        Term::CLI::Command->new(
+            name        => 'down',
+            summary     => 'Shut down I<iface>',
+            description => 'Shut down the I<iface> interface.',
+            callback    => sub {
+                my ( $cmd, %args ) = @_;
+                return %args if $args{status} < 0;
+                my @args = @{ $args{arguments} };
+                say "shutting down $args[0]";
+                return %args;
+            }
+        ),
+    ],
+);
+
+push @commands, Term::CLI::Command->new(
+    name        => 'debug',
+    usage       => 'B<debug> I<cmd> ...',
+    summary     => 'debug commands',
+    description => "Print some debugging information regarding\n"
+        . "the execution of I<cmd>.",
+    commands => \@commands,
+    callback => sub {
+        my ( $cmd, %args ) = @_;
+        my @args = @{ $args{arguments} };
+        say "# --- DEBUG ---";
+        my $d = Data::Dumper->new( [ \%args ], [qw(args)] );
+        print $d->Maxdepth(2)->Indent(1)->Terse(1)->Dump;
+        say "# --- DEBUG ---";
+        return %args;
+    }
+);
+
+push @commands, Term::CLI::Command->new(
+    name        => 'suspend',
+    summary     => 'suspend the program',
+    description => "Suspend the program by sending a C<TSTP>\n"
+        . "signal and return control to the shell.",
+    callback => sub {
+        my ( $cmd, %args ) = @_;
+        return %args if $args{status} < 0;
+        local ( $SIG{TSTP} ) = 'DEFAULT';
+        kill 'TSTP', $$;
+        return %args;
+    }
+);
+
+$term->add_command(@commands);
+
+$term->read_history();
+
+say "\n[Welcome to BSSH]";
+while ( defined( my $line = $term->readline ) ) {
+    $term->execute_line($line);
+}
+print "\n";
+execute_exit( $term, 0 );

--- a/tutorial/example_18_dynamic_enum.pl
+++ b/tutorial/example_18_dynamic_enum.pl
@@ -260,7 +260,7 @@ push @commands, Term::CLI::Command->new(
                 Term::CLI::Argument::Bool->new(
                     name         => 'bool',
                     true_values  => [qw( 1 true on yes ok )],
-                    false_values => [qw( 1 false off no never )],
+                    false_values => [qw( 0 false off no never )],
                 )
 
             ],


### PR DESCRIPTION
- Implement context-sensitive completion. Introduce a second argument to `complete`, a HashRef with "state" information that includes the preceding words on the command line (in the `$state->{processed}` ArrayRef) and a collection of options seen so far (in the `$state->{options}` HashRef).

- Add a simple demo/test script in `examples/context_sensitive_completion` to test context-sensitive completion.

- Argument validation now receives a similar "state" parameter, although it has a different structure than that of `complete` (it is, in fact, the same as the one for `execute`).

- Minor bug fix in Tutorial code.
- Add tutorial entry for dynamic Enum values.
- Enum's _fetch_values has been promoted to a public values method.
- Addition of caching option for Enum value list (in case you want to load the list on-demand, but only once).
-  Addition of a Util module that takes some common code and puts it in one place (option parsing, string prefix matching).
-  Small enhancement of Boolean completion (completions now match case of the partial text).
-  Create ReadLine object that uses STDIN and STDOUT by default, instead of letting (Gnu) ReadLine find and open the TTY separately. This ensures that `perl readline_app < input_file` will actually read input from input_file, while also making sure that whatever encoding you have on the standard file handles (use open `qw(:std :utf8)`) will also be applied to the ReadLine I/O. This will ensure that Estonians can write "tõsi" for "true" and Macedonians can write "лажни" for "false".
- Various POD fixes.
